### PR TITLE
Fix pydantic definition for error scenarios when invoking SQL tool.

### DIFF
--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -268,7 +268,7 @@ class RunSqlQuery(Tools):
         )
 
     @secured
-    async def invoke(self, s: str) -> Dict[str, List[Dict[Any, Any]]]:
+    async def invoke(self, s: str) -> Dict[str, Union[List[Dict[Any, Any]] | str]]:
         """Run a SELECT sql query on the Dremio cluster and return the results.
         Ensure that SQL keywords like 'day', 'month', 'count', 'table' etc are enclosed in double quotes
         You are premitted to run only SELECT queries. No DML statements are allowed.


### PR DESCRIPTION
When the tool encounters an error (i.e. invalid SQL), the structure is a Dict[str, str] which causes Pydantic to throw an error validating the output structure. This prevents the MCP from returning helpful context to the model.