### PR TITLE
Fix docker workflow after PR #59

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Test container
         run: |
-          uv run python tests/stremable_http_cli.py --url http://127.0.0.1:6789/mcp --token fake
+          uv run python tests/stremable_http_cli.py cli list-tools --url http://127.0.0.1:6789/mcp --token fake
       - id: tag
         name: Create tag
         run: |


### PR DESCRIPTION
After pr #59, docker workflow requires `cli list-tools`.