### PR TITLE
DX-113627: Make RunSqlQuery JSON-safe output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ async def http_streamable_mcp_server(
     logging_level: str,
     project_id: str = None,
     wlm_engine: str = None,
-) -> AsyncGenerator[StreamableMcpServerFixture]:
+) -> AsyncGenerator[StreamableMcpServerFixture, None]:
     old = settings.instance()
     sf = None
     try:
@@ -279,7 +279,7 @@ async def http_streamable_mcp_server(
 @contextlib.asynccontextmanager
 async def http_streamable_client_server(
     sf: ServerFixture, token=None
-) -> AsyncGenerator[ClientSession]:
+) -> AsyncGenerator[ClientSession, None]:
     headers = {"Authorization": f"Bearer {token}"} if token is not None else None
     async with streamablehttp_client(url=sf.url, headers=headers) as (
         read_stream,


### PR DESCRIPTION
Codex implemented it and tested based on the feedback from Jorge:
```
The SQL is "SELECT * FROM reporting.telemetry.stg_telemetry_metrics WHERE LOWER(org_name) = 'mobilityware'" and it was originally created by ChatGPT but fails both with Claude and ChatGPT. The error is basically "Error executing tool RunSqlQuery: Error serializing to JSON: TypeError: 'float' object cannot be interpreted as an integer" for both LLMs. It runs fine with the Dremio AI Agent. I wrote an equivalent SQL and it worked fine on all agents (ChatGPT, Claude and the Dremio AI Agent).
```

Change in tests/conftest.py was required to run tests, otherwise they didn't run with python 3.12.