### PR TITLE
DX-119521: Support VIZ category in enterprise search results

### DIFF
--- a/src/dremioai/api/dremio/search.py
+++ b/src/dremioai/api/dremio/search.py
@@ -85,6 +85,7 @@ class Category(UStrEnum):
     REFLECTION = auto()
     SCRIPT = auto()
     SOURCE = auto()
+    VIZ = auto()
 
 
 class UserOrRole(UStrEnum):


### PR DESCRIPTION
## Summary
- Added `VIZ` to the `Category` enum in `search.py` to handle Dremio's visualization search results
- Fixes a `RuntimeError` raised by Pydantic when the enterprise search API returns results with `category='VIZ'`

## Test plan
- [ ] Run the search tool against a Dremio instance that has VIZ results and confirm no validation errors
- [ ] Confirm other category types still parse correctly

Fixes [DX-119521](https://dremio.atlassian.net/browse/DX-119521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DX-119521]: https://dremio.atlassian.net/browse/DX-119521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ