### PR TITLE
DX-119753: Switch Streamable HTTP to stateless mode + add session-aware diagnostics

### DIFF
--- a/src/dremioai/log.py
+++ b/src/dremioai/log.py
@@ -105,6 +105,7 @@ def configure(enable_json_logging=None, to_file=False):
         else structlog.dev.ConsoleRenderer()
     )
     processors = [
+        structlog.contextvars.merge_contextvars,
         structlog.processors.add_log_level,
         structlog.processors.TimeStamper(),
         structlog.stdlib.filter_by_level,

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -59,6 +59,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.responses import Response as StarletteResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from structlog.contextvars import bound_contextvars
 from typer import Argument, BadParameter, Option, Typer
 from yaml import dump
@@ -73,6 +74,92 @@ from dremioai.metrics.tool_metrics import invocation_counter, invocation_duratio
 from dremioai.servers.jwks_verifier import JWKSVerifier, TokenExpiredError
 from dremioai.tools import tools
 from dremioai.tools.tools import ProjectIdMiddleware
+
+
+class MCPTransportLoggingMiddleware:
+    logger = log.logger("MCPTransportLoggingMiddleware")
+    max_error_body_log_bytes = 2048
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http" or not scope.get("path", "").startswith("/mcp"):
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
+        status_code = None
+        response_headers: List[Tuple[bytes, bytes]] = []
+        captured_body = bytearray()
+        response_body_truncated = False
+
+        async def send_wrapper(message: Message):
+            nonlocal status_code, response_headers, response_body_truncated
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                response_headers = message.get("headers", [])
+            elif (
+                message["type"] == "http.response.body"
+                and status_code is not None
+                and status_code >= 400
+            ):
+                body = message.get("body", b"")
+                remaining = self.max_error_body_log_bytes - len(captured_body)
+                if remaining > 0:
+                    captured_body.extend(body[:remaining])
+                if len(body) > remaining:
+                    response_body_truncated = True
+
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception:
+            self.logger.exception(
+                "MCP transport request failed with exception",
+                **self._request_log_context(request),
+            )
+            raise
+
+        if status_code is not None and status_code >= 400:
+            response_body = (
+                captured_body.decode("utf-8", errors="replace").strip()
+                if captured_body
+                else None
+            )
+            self.logger.warning(
+                "MCP transport request failed",
+                status_code=status_code,
+                response_body=response_body,
+                response_body_truncated=response_body_truncated,
+                response_mcp_session_id=self._header(
+                    response_headers, MCP_SESSION_ID_HEADER
+                ),
+                **self._request_log_context(request),
+            )
+
+    @staticmethod
+    def _header(headers: List[Tuple[bytes, bytes]], name: str) -> str | None:
+        expected = name.lower().encode()
+        for key, value in headers:
+            if key.lower() == expected:
+                return value.decode("utf-8", errors="replace")
+        return None
+
+    @staticmethod
+    def _request_log_context(request: Request) -> Dict[str, Any]:
+        context = {
+            "method": request.method,
+            "path": request.url.path,
+            "client": request.client.host if request.client else None,
+            "mcp_session_id": request.headers.get(MCP_SESSION_ID_HEADER),
+            "mcp_protocol_version": request.headers.get(MCP_PROTOCOL_VERSION_HEADER),
+            "accept": request.headers.get("accept"),
+            "content_type": request.headers.get("content-type"),
+            "project_id": ProjectIdMiddleware.get_project_id(),
+        }
+        return {key: value for key, value in context.items() if value is not None}
 
 
 class RequireAuthWithWWWAuthenticateMiddleware(BaseHTTPMiddleware):
@@ -208,6 +295,7 @@ class FastMCPServerWithAuthToken(FastMCP):
         else:
             token_verifier = FastMCPServerWithAuthToken.DelegatingTokenVerifier()
         app = super().streamable_http_app()
+        app.add_middleware(MCPTransportLoggingMiddleware)
         app.add_middleware(RequireAuthWithWWWAuthenticateMiddleware)
         app.add_middleware(AuthContextMiddleware)
         app.add_middleware(
@@ -319,6 +407,8 @@ def init(
         f"Initializing MCP server with mode={mode}, mock={mock}, class={mcp_cls.__name__}"
     )
     opts = {"log_level": "DEBUG", "debug": True, "lifespan": _server_lifespan}
+    if transport == Transports.streamable_http:
+        opts["stateless_http"] = True
     if port is not None:
         opts["port"] = port
     if host is not None:

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -23,6 +23,7 @@ import time
 from uuid import uuid4
 from enum import StrEnum, auto
 from functools import reduce, wraps
+from http import HTTPStatus
 from json import dump as jdump
 from json import load
 from operator import ior
@@ -54,6 +55,7 @@ from pydantic import AnyHttpUrl
 from pydantic.networks import AnyUrl
 from rich import console, table
 from rich import print as pp
+from starlette.datastructures import Headers
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -78,6 +80,7 @@ from dremioai.tools.tools import ProjectIdMiddleware
 
 class MCPTransportLoggingMiddleware:
     logger = log.logger("MCPTransportLoggingMiddleware")
+    status_to_log = HTTPStatus.MULTIPLE_CHOICES  # log 300 and above
     max_error_body_log_bytes = 2048
 
     def __init__(self, app: ASGIApp):
@@ -102,7 +105,7 @@ class MCPTransportLoggingMiddleware:
             elif (
                 message["type"] == "http.response.body"
                 and status_code is not None
-                and status_code >= 400
+                and status_code >= self.status_to_log
             ):
                 body = message.get("body", b"")
                 remaining = self.max_error_body_log_bytes - len(captured_body)
@@ -122,7 +125,7 @@ class MCPTransportLoggingMiddleware:
             )
             raise
 
-        if status_code is not None and status_code >= 400:
+        if status_code is not None and status_code >= self.status_to_log:
             response_body = (
                 captured_body.decode("utf-8", errors="replace").strip()
                 if captured_body
@@ -133,19 +136,11 @@ class MCPTransportLoggingMiddleware:
                 status_code=status_code,
                 response_body=response_body,
                 response_body_truncated=response_body_truncated,
-                response_mcp_session_id=self._header(
-                    response_headers, MCP_SESSION_ID_HEADER
+                response_mcp_session_id=Headers(raw=response_headers).get(
+                    MCP_SESSION_ID_HEADER
                 ),
                 **self._request_log_context(request),
             )
-
-    @staticmethod
-    def _header(headers: List[Tuple[bytes, bytes]], name: str) -> str | None:
-        expected = name.lower().encode()
-        for key, value in headers:
-            if key.lower() == expected:
-                return value.decode("utf-8", errors="replace")
-        return None
 
     @staticmethod
     def _request_log_context(request: Request) -> Dict[str, Any]:

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -34,12 +34,20 @@ import uvicorn
 from click import Choice
 from mcp.cli.claude import get_claude_config_path
 from mcp.server.auth.json_response import PydanticJSONResponse
-from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_access_token
+from mcp.server.auth.middleware.auth_context import (
+    AuthContextMiddleware,
+    get_access_token,
+)
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.prompts import Prompt
 from mcp.server.fastmcp.resources import FunctionResource
+from mcp.server.lowlevel.server import request_ctx
+from mcp.server.streamable_http import (
+    MCP_PROTOCOL_VERSION_HEADER,
+    MCP_SESSION_ID_HEADER,
+)
 from mcp.types import ToolAnnotations
 from pydantic import AnyHttpUrl
 from pydantic.networks import AnyUrl
@@ -229,18 +237,64 @@ def _make_mock_invoke(tool_class_name: str, original_doc: str):
     return mock_invoke
 
 
+def _mcp_request_log_context() -> Dict[str, Any]:
+    try:
+        ctx = request_ctx.get()
+    except LookupError:
+        return {}
+
+    request = getattr(ctx, "request", None)
+    log_context: Dict[str, Any] = {
+        "jsonrpc_request_id": str(ctx.request_id),
+    }
+    if request is not None:
+        log_context.update(
+            {
+                "mcp_session_id": request.headers.get(MCP_SESSION_ID_HEADER),
+                "mcp_protocol_version": request.headers.get(
+                    MCP_PROTOCOL_VERSION_HEADER
+                ),
+                "client": request.client.host if request.client else None,
+                "method": request.method,
+                "path": request.url.path,
+            }
+        )
+
+    if project_id := ProjectIdMiddleware.get_project_id():
+        log_context["project_id"] = project_id
+
+    if isinstance((token := get_access_token()), AccessToken):
+        log_context["user_id"] = token.client_id
+
+    return {key: value for key, value in log_context.items() if value is not None}
+
+
 def make_logged_invoke(tool_name: str, fn):
     _log = log.logger("tool_invoke")
 
     @wraps(fn)
     async def _wrapper(*args, **kwargs):
+        started = time.perf_counter()
+        log_context = _mcp_request_log_context()
         try:
-            return await fn(*args, **kwargs)
+            result = await fn(*args, **kwargs)
+            _log.info(
+                "Tool invocation completed",
+                tool=tool_name,
+                outcome="success",
+                duration_ms=round((time.perf_counter() - started) * 1000, 3),
+                **log_context,
+            )
+            return result
         except Exception as exc:
             _log.warning(
                 "Tool invocation raised an exception",
                 tool=tool_name,
+                outcome="error",
+                duration_ms=round((time.perf_counter() - started) * 1000, 3),
+                error_type=type(exc).__name__,
                 error=str(exc),
+                **log_context,
             )
             raise
 
@@ -295,13 +349,15 @@ def init(
         tool_instance = tool()
         is_sql_tool = tool is tools.RunSqlQuery
         if mock:
-            invoke_fn = _make_mock_invoke(
-                tool.__name__, tool_instance.invoke.__doc__
-            )
+            invoke_fn = _make_mock_invoke(tool.__name__, tool_instance.invoke.__doc__)
         else:
             invoke_fn = tool_instance.invoke
         mcp.add_tool(
-            invoke_fn if mock else make_logged_invoke(tool.__name__, tool_instance.invoke),
+            (
+                invoke_fn
+                if mock
+                else make_logged_invoke(tool.__name__, tool_instance.invoke)
+            ),
             name=tool.__name__,
             description=tool_instance.invoke.__doc__,
             annotations=ToolAnnotations(

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -20,6 +20,7 @@ import os
 import sys
 import threading
 import time
+from uuid import uuid4
 from enum import StrEnum, auto
 from functools import reduce, wraps
 from json import dump as jdump
@@ -58,6 +59,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.responses import Response as StarletteResponse
+from structlog.contextvars import bound_contextvars
 from typer import Argument, BadParameter, Option, Typer
 from yaml import dump
 
@@ -275,28 +277,29 @@ def make_logged_invoke(tool_name: str, fn):
     @wraps(fn)
     async def _wrapper(*args, **kwargs):
         started = time.perf_counter()
-        log_context = _mcp_request_log_context()
-        try:
-            result = await fn(*args, **kwargs)
-            _log.info(
-                "Tool invocation completed",
-                tool=tool_name,
-                outcome="success",
-                duration_ms=round((time.perf_counter() - started) * 1000, 3),
-                **log_context,
-            )
-            return result
-        except Exception as exc:
-            _log.warning(
-                "Tool invocation raised an exception",
-                tool=tool_name,
-                outcome="error",
-                duration_ms=round((time.perf_counter() - started) * 1000, 3),
-                error_type=type(exc).__name__,
-                error=str(exc),
-                **log_context,
-            )
-            raise
+        log_context = {
+            **_mcp_request_log_context(),
+            "tool": tool_name,
+            "tool_invocation_id": str(uuid4()),
+        }
+        with bound_contextvars(**log_context):
+            try:
+                result = await fn(*args, **kwargs)
+                _log.info(
+                    "Tool invocation completed",
+                    outcome="success",
+                    duration_ms=round((time.perf_counter() - started) * 1000, 3),
+                )
+                return result
+            except Exception as exc:
+                _log.warning(
+                    "Tool invocation raised an exception",
+                    outcome="error",
+                    duration_ms=round((time.perf_counter() - started) * 1000, 3),
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                raise
 
     return _wrapper
 

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -31,10 +31,17 @@ from mcp.server.streamable_http import (
 )
 from mcp.shared.context import RequestContext
 from starlette.requests import Request
+from starlette.responses import Response
 
 from dremioai import log
 from dremioai.servers.jwks_verifier import JWKSVerifier, VerifiedClaims, TokenExpiredError
-from dremioai.servers.mcp import make_logged_invoke, RequireAuthWithWWWAuthenticateMiddleware
+from dremioai.servers.mcp import (
+    MCPTransportLoggingMiddleware,
+    Transports,
+    init,
+    make_logged_invoke,
+    RequireAuthWithWWWAuthenticateMiddleware,
+)
 
 JWKS_DECODE = "dremioai.servers.jwks_verifier.pyjwt.decode"
 
@@ -270,6 +277,75 @@ class TestDispatchWarning:
             "/mcp/tools" in str(r.message) or "192.168.1.1" in str(r.message)
             for r in warning_records
         )
+
+
+class TestMCPTransportLoggingMiddleware:
+    @pytest.mark.asyncio
+    async def test_logs_transport_error_context(self, caplog):
+        async def app(scope, receive, send):
+            response = Response(
+                "Bad Request: Unsupported protocol version: 2025-11-25",
+                status_code=400,
+                headers={MCP_SESSION_ID_HEADER: "response-session"},
+            )
+            await response(scope, receive, send)
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/project-123",
+            "headers": [
+                (MCP_SESSION_ID_HEADER.encode(), b"request-session"),
+                (MCP_PROTOCOL_VERSION_HEADER.encode(), b"2025-11-25"),
+                (b"accept", b"application/json, text/event-stream"),
+                (b"content-type", b"application/json"),
+                (b"authorization", b"Bearer secret-token"),
+            ],
+            "client": ("203.0.113.10", 4321),
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "query_string": b"",
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        sent_messages = []
+
+        async def send(message):
+            sent_messages.append(message)
+
+        middleware = MCPTransportLoggingMiddleware(app)
+        with caplog.at_level(logging.WARNING):
+            await middleware(scope, receive, send)
+
+        warning_messages = [
+            str(r.message) for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any("MCP transport request failed" in msg for msg in warning_messages)
+        logged = "\n".join(warning_messages)
+        assert "request-session" in logged
+        assert "response-session" in logged
+        assert "2025-11-25" in logged
+        assert "Unsupported protocol version" in logged
+        assert "203.0.113.10" in logged
+        assert "secret-token" not in logged
+
+
+class TestStreamableHttpInit:
+    def test_streamable_http_transport_is_stateless(self):
+        with patch("dremioai.servers.mcp.tools.get_tools", return_value=[]), patch(
+            "dremioai.servers.mcp.tools.get_resources", return_value=[]
+        ):
+            mcp = init(
+                mode=None,
+                transport=Transports.streamable_http,
+                host="127.0.0.1",
+                port=8000,
+                mock=True,
+            )
+
+        assert mcp.settings.stateless_http is True
 
 
 class TestMakeLoggedInvoke:

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -24,6 +24,13 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import jwt as pyjwt
 from jwt import PyJWKClient, PyJWKClientError, ExpiredSignatureError
+from mcp.server.lowlevel.server import request_ctx
+from mcp.server.streamable_http import (
+    MCP_PROTOCOL_VERSION_HEADER,
+    MCP_SESSION_ID_HEADER,
+)
+from mcp.shared.context import RequestContext
+from starlette.requests import Request
 
 from dremioai.servers.jwks_verifier import JWKSVerifier, VerifiedClaims, TokenExpiredError
 from dremioai.servers.mcp import make_logged_invoke, RequireAuthWithWWWAuthenticateMiddleware
@@ -293,3 +300,65 @@ class TestMakeLoggedInvoke:
         assert result == "ok"
         warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warning_records) == 0
+
+    @pytest.mark.asyncio
+    async def test_logs_info_on_success(self, caplog):
+        async def ok_fn():
+            return "ok"
+
+        wrapped = make_logged_invoke("good_tool", ok_fn)
+        with caplog.at_level(logging.INFO):
+            result = await wrapped()
+        assert result == "ok"
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any(
+            "Tool invocation completed" in str(r.message)
+            and "good_tool" in str(r.message)
+            and "success" in str(r.message)
+            for r in info_records
+        )
+
+    @pytest.mark.asyncio
+    async def test_logs_mcp_request_context(self, caplog):
+        async def ok_fn():
+            return "ok"
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/mcp/project-123",
+                "headers": [
+                    (MCP_SESSION_ID_HEADER.encode(), b"session-abc"),
+                    (MCP_PROTOCOL_VERSION_HEADER.encode(), b"2025-06-18"),
+                ],
+                "client": ("192.0.2.10", 4321),
+                "server": ("testserver", 80),
+                "scheme": "http",
+            }
+        )
+        token = request_ctx.set(
+            RequestContext(
+                request_id="rpc-123",
+                meta=None,
+                session=None,
+                lifespan_context=None,
+                request=request,
+            )
+        )
+        try:
+            wrapped = make_logged_invoke("context_tool", ok_fn)
+            with caplog.at_level(logging.INFO):
+                result = await wrapped()
+        finally:
+            request_ctx.reset(token)
+
+        assert result == "ok"
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any(
+            "session-abc" in str(r.message)
+            and "rpc-123" in str(r.message)
+            and "192.0.2.10" in str(r.message)
+            and "context_tool" in str(r.message)
+            for r in info_records
+        )

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -32,6 +32,7 @@ from mcp.server.streamable_http import (
 from mcp.shared.context import RequestContext
 from starlette.requests import Request
 
+from dremioai import log
 from dremioai.servers.jwks_verifier import JWKSVerifier, VerifiedClaims, TokenExpiredError
 from dremioai.servers.mcp import make_logged_invoke, RequireAuthWithWWWAuthenticateMiddleware
 
@@ -274,6 +275,15 @@ class TestDispatchWarning:
 class TestMakeLoggedInvoke:
     """Tests for make_logged_invoke WARNING logging on tool exceptions."""
 
+    @pytest.fixture
+    def info_logging(self):
+        previous_level = log.level()
+        log.set_level(logging.INFO)
+        try:
+            yield
+        finally:
+            log.set_level(previous_level)
+
     @pytest.mark.asyncio
     async def test_logs_warning_on_exception(self, caplog):
         async def failing_fn():
@@ -302,7 +312,7 @@ class TestMakeLoggedInvoke:
         assert len(warning_records) == 0
 
     @pytest.mark.asyncio
-    async def test_logs_info_on_success(self, caplog):
+    async def test_logs_info_on_success(self, caplog, info_logging):
         async def ok_fn():
             return "ok"
 
@@ -319,7 +329,7 @@ class TestMakeLoggedInvoke:
         )
 
     @pytest.mark.asyncio
-    async def test_logs_mcp_request_context(self, caplog):
+    async def test_logs_mcp_request_context(self, caplog, info_logging):
         async def ok_fn():
             return "ok"
 

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -331,6 +331,41 @@ class TestMCPTransportLoggingMiddleware:
         assert "203.0.113.10" in logged
         assert "secret-token" not in logged
 
+    @pytest.mark.asyncio
+    async def test_logs_redirects(self, caplog):
+        async def app(scope, receive, send):
+            response = Response(status_code=307, headers={"location": "/mcp/new"})
+            await response(scope, receive, send)
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/mcp/project-123",
+            "headers": [],
+            "client": ("203.0.113.10", 4321),
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "query_string": b"",
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(_message):
+            pass
+
+        middleware = MCPTransportLoggingMiddleware(app)
+        with caplog.at_level(logging.WARNING):
+            await middleware(scope, receive, send)
+
+        warning_messages = [
+            str(r.message) for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(
+            "MCP transport request failed" in msg and "307" in msg
+            for msg in warning_messages
+        )
+
 
 class TestStreamableHttpInit:
     def test_streamable_http_transport_is_stateless(self):

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -372,3 +372,63 @@ class TestMakeLoggedInvoke:
             and "context_tool" in str(r.message)
             for r in info_records
         )
+
+    @pytest.mark.asyncio
+    async def test_propagates_mcp_request_context_to_nested_logs(
+        self, caplog, info_logging
+    ):
+        nested_logger = log.logger("nested_tool_log")
+
+        async def ok_fn():
+            nested_logger.info("Nested tool log")
+            return "ok"
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/mcp/project-123",
+                "headers": [
+                    (MCP_SESSION_ID_HEADER.encode(), b"session-abc"),
+                    (MCP_PROTOCOL_VERSION_HEADER.encode(), b"2025-06-18"),
+                ],
+                "client": ("192.0.2.10", 4321),
+                "server": ("testserver", 80),
+                "scheme": "http",
+            }
+        )
+        token = request_ctx.set(
+            RequestContext(
+                request_id="rpc-123",
+                meta=None,
+                session=None,
+                lifespan_context=None,
+                request=request,
+            )
+        )
+        try:
+            wrapped = make_logged_invoke("context_tool", ok_fn)
+            with caplog.at_level(logging.INFO):
+                result = await wrapped()
+                nested_logger.info("Outside invocation")
+        finally:
+            request_ctx.reset(token)
+
+        assert result == "ok"
+        nested_records = [
+            r for r in caplog.records if "Nested tool log" in str(r.message)
+        ]
+        assert len(nested_records) == 1
+        nested_message = str(nested_records[0].message)
+        assert "session-abc" in nested_message
+        assert "rpc-123" in nested_message
+        assert "context_tool" in nested_message
+        assert "tool_invocation_id" in nested_message
+
+        outside_records = [
+            r for r in caplog.records if "Outside invocation" in str(r.message)
+        ]
+        assert len(outside_records) == 1
+        outside_message = str(outside_records[0].message)
+        assert "session-abc" not in outside_message
+        assert "tool_invocation_id" not in outside_message


### PR DESCRIPTION
## Summary

Jira:
- https://dremio.atlassian.net/browse/DX-119753
- https://dremio.atlassian.net/browse/DX-118422

Adds MCP request correlation and transport diagnostics for Streamable HTTP, then switches Streamable HTTP to stateless mode to avoid stale in-memory MCP session failures after server/pod restarts.

## RCA

While testing Claude through ngrok against a local MCP server, the server was restarted after Claude had already initialized an MCP Streamable HTTP session. Claude then reused the old session id on the next tool call:

```http
POST /mcp/<project_id> HTTP/1.1
Accept: application/json, text/event-stream
Mcp-Protocol-Version: 2025-06-18
Mcp-Session-Id: cc09fe87d1944e0996d15687c69286de

{"method":"tools/call","params":{"name":"RunSqlQuery","arguments":{"query":"SELECT 1"}},"jsonrpc":"2.0","id":1}
```

The restarted server returned:

```http
HTTP/1.1 400 Bad Request

Bad Request: No valid session ID provided
```

The request had a valid protocol version and did include `Mcp-Session-Id`. The failure was that the Python MCP SDK stores Streamable HTTP session transports in process memory. After a restart, the server's `_server_instances` map is empty, so Claude's old session id is unknown.

The MCP Streamable HTTP spec expects stale/expired session recovery via `404`, allowing clients to reinitialize. The current Python SDK returns `400` for this unknown-session path, which can prevent Claude from recovering cleanly.

## Changes

- Adds `structlog.contextvars.merge_contextvars` to the logging pipeline.
- Binds MCP request context for the entire tool invocation scope with `bound_contextvars`, so logs emitted below the tool wrapper include the same correlation fields.
- Adds a per-call `tool_invocation_id` so multiple calls in the same MCP session can be distinguished.
- Adds `MCPTransportLoggingMiddleware` around `/mcp...` requests to log safe 3xx and above transport diagnostics before a tool invocation exists.
- Enables FastMCP `stateless_http=True` for Streamable HTTP so server restarts and non-sticky routing do not invalidate idle clients via process-local MCP session state.

Logged tool invocation fields include:
- tool name, outcome, duration
- MCP session id and protocol version when available
- JSON-RPC request id
- tool invocation id
- client host, request method/path
- project id and authenticated user id when available
- error type/message for failed invocations

Logged transport failure fields include:
- status code
- response error body, truncated to 2048 bytes
- request/response MCP session id when present
- MCP protocol version
- request method/path/client
- `Accept` and `Content-Type`
- project id when available

This intentionally does not log bearer tokens, request bodies, tool arguments, SQL text, result data, or Authorization headers. It also avoids adding session/user labels to Prometheus metrics to prevent high-cardinality metrics.

## Repro

1. Use a config like:

```yaml
dremio:
  enable_search: true
  allow_dml: true
  project_id: DREMIO_DYNAMIC
  uri: https://api.dev.dremio.site
tools:
  server_mode: FOR_DATA_PATTERNS
```

2. Start the server:

```bash
uv run dremio-mcp-server run --enable-streaming-http --no-log-to-file --log-level DEBUG
```

3. Expose it:

```bash
ngrok http 8000
```

4. Add the ngrok project-scoped URL to Claude as an MCP connector:

```text
https://<ngrok-host>/mcp/<project_id>
```

5. Call `RunSqlQuery` with `SELECT 1`.
6. Restart the MCP server while leaving the Claude connector/session in place.
7. Call `RunSqlQuery` again.

Pre-fix, Claude reuses the stale `Mcp-Session-Id` and the SDK returns `400 Bad Request: No valid session ID provided`.

## Testing

- `uv run pytest tests/servers/test_jwks_verifier.py::TestMCPTransportLoggingMiddleware tests/servers/test_jwks_verifier.py::TestStreamableHttpInit tests/servers/test_jwks_verifier.py::TestMakeLoggedInvoke -q`
- `uv run pytest tests/test_log.py -q`
- `uv run pytest tests/config/test_launchdarkly_integration.py::test_log_level_refresh_updates_level tests/config/test_launchdarkly_integration.py::test_log_level_refresh_no_change_when_same tests/servers/test_jwks_verifier.py::TestMakeLoggedInvoke -q`
- `uv run black --check --diff --workers 1 src/dremioai/servers/mcp.py`
