### PR TITLE
Fix: remove dead copy_context() in run_with

### DIFF
--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -48,7 +48,7 @@ from yaml import add_representer, dump
 from functools import reduce
 from operator import ior
 from shutil import which
-from contextvars import ContextVar, copy_context
+from contextvars import ContextVar
 from os import environ
 from importlib.util import find_spec
 from datetime import datetime
@@ -578,7 +578,6 @@ async def run_with(
         finally:
             _settings.reset(tok)
 
-    ctx = copy_context()
     return await _call()
 
 


### PR DESCRIPTION
## Summary

- Removes `ctx = copy_context()` in `run_with` — it was assigned but never used
- Removes the now-unused `copy_context` import

## Analysis (re: #91)

The `ctx.run()` fix suggested in the issue is not valid for async functions — `ctx.run(async_func)` returns a coroutine without executing its body; the body runs in the caller's context when awaited.

The existing token-based pattern is already correct:
- `_settings.set()` returns a token capturing the previous value
- `_settings.reset(tok)` in `finally` restores it unconditionally

The race described in the issue (concurrent `_settings.set()` within the same Task) cannot be triggered by normal asyncio usage: `asyncio.gather` wraps coroutines in Tasks, each of which gets its own ContextVar copy at creation time.

No behavioral change — this is dead code removal only.

Closes #91

## Test plan
- [ ] `uv run pytest tests/ -v` passes
- [ ] `python -c "from dremioai.config.settings import run_with"` imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)