### PR TITLE
DX-120403 Route streamable HTTP logging through JSON formatter

### DIFF
--- a/src/dremioai/log.py
+++ b/src/dremioai/log.py
@@ -20,7 +20,6 @@ import os
 import sys
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
-from logging import basicConfig
 
 
 def get_log_directory(app_name: str = "dremioai") -> Path:
@@ -57,6 +56,13 @@ def logger(name=None):
 
 
 _level = None
+
+
+def _rename_exception_field(_logger, _name, event_dict):
+    """Use stacktrace for JSON logs to keep exception payloads machine-friendly."""
+    if (exception := event_dict.pop("exception", None)) is not None:
+        event_dict["stacktrace"] = exception
+    return event_dict
 
 
 def configure_file_logging(enable_json=False):
@@ -104,13 +110,11 @@ def configure(enable_json_logging=None, to_file=False):
         if enable_json_logging
         else structlog.dev.ConsoleRenderer()
     )
-    processors = [
+    shared_processors = [
         structlog.contextvars.merge_contextvars,
-        structlog.processors.add_log_level,
-        structlog.processors.TimeStamper(),
-        structlog.stdlib.filter_by_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
+        structlog.stdlib.ExtraAdder(),
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
@@ -121,11 +125,30 @@ def configure(enable_json_logging=None, to_file=False):
                 structlog.processors.CallsiteParameter.LINENO,
             }
         ),
+    ]
+    formatter_processors = [
+        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+    ]
+    if enable_json_logging:
+        formatter_processors.append(_rename_exception_field)
+    formatter_processors.extend(
+        [
         structlog.processors.EventRenamer("message"),
         renderer,
-    ]
+        ]
+    )
+    handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processors=formatter_processors,
+            foreign_pre_chain=shared_processors,
+        )
+    )
     structlog.configure(
-        processors=processors,
+        processors=[
+            structlog.stdlib.filter_by_level,
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
         context_class=dict,
         wrapper_class=structlog.stdlib.BoundLogger,
         logger_factory=(structlog.stdlib.LoggerFactory()),

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -92,6 +92,7 @@ class MCPTransportLoggingMiddleware:
             return
 
         request = Request(scope)
+        started = time.perf_counter()
         status_code = None
         response_headers: List[Tuple[bytes, bytes]] = []
         captured_body = bytearray()
@@ -121,26 +122,34 @@ class MCPTransportLoggingMiddleware:
         except Exception:
             self.logger.exception(
                 "MCP transport request failed with exception",
+                duration_ms=round((time.perf_counter() - started) * 1000, 3),
                 **self._request_log_context(request),
             )
             raise
 
-        if status_code is not None and status_code >= self.status_to_log:
-            response_body = (
-                captured_body.decode("utf-8", errors="replace").strip()
-                if captured_body
-                else None
-            )
-            self.logger.warning(
-                "MCP transport request failed",
-                status_code=status_code,
-                response_body=response_body,
-                response_body_truncated=response_body_truncated,
-                response_mcp_session_id=Headers(raw=response_headers).get(
+        if status_code is not None:
+            event = {
+                "status_code": status_code,
+                "duration_ms": round((time.perf_counter() - started) * 1000, 3),
+                "response_mcp_session_id": Headers(raw=response_headers).get(
                     MCP_SESSION_ID_HEADER
                 ),
                 **self._request_log_context(request),
-            )
+            }
+            if status_code >= self.status_to_log:
+                response_body = (
+                    captured_body.decode("utf-8", errors="replace").strip()
+                    if captured_body
+                    else None
+                )
+                self.logger.warning(
+                    "MCP transport request failed",
+                    response_body=response_body,
+                    response_body_truncated=response_body_truncated,
+                    **event,
+                )
+            else:
+                self.logger.info("MCP transport request completed", **event)
 
     @staticmethod
     def _request_log_context(request: Request) -> Dict[str, Any]:
@@ -305,6 +314,27 @@ class FastMCPServerWithAuthToken(FastMCP):
 
         # Metrics are now served on a separate port, not mounted here
         return app
+
+    async def run_streamable_http_async(self) -> None:
+        """Run StreamableHTTP with Uvicorn access logs disabled.
+
+        FastMCP.run() dispatches here polymorphically for the streamable-http
+        transport, so overriding this method is enough to replace the base
+        Uvicorn configuration used by the CLI server path.
+
+        Access logging is handled by MCPTransportLoggingMiddleware so it can
+        share the application's structured logging pipeline.
+        """
+        starlette_app = self.streamable_http_app()
+        config = uvicorn.Config(
+            starlette_app,
+            host=self.settings.host,
+            port=self.settings.port,
+            log_level=self.settings.log_level.lower(),
+            access_log=False,
+        )
+        server = uvicorn.Server(config)
+        await server.serve()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -299,18 +299,19 @@ class FastMCPServerWithAuthToken(FastMCP):
         else:
             token_verifier = FastMCPServerWithAuthToken.DelegatingTokenVerifier()
         app = super().streamable_http_app()
-        app.add_middleware(MCPTransportLoggingMiddleware)
         app.add_middleware(RequireAuthWithWWWAuthenticateMiddleware)
         app.add_middleware(AuthContextMiddleware)
         app.add_middleware(
             AuthenticationMiddleware, backend=BearerAuthBackend(token_verifier)
         )
-        # Add middleware in reverse order (last added = first executed)
+        # Starlette inserts middleware at the front, so the last added middleware
+        # runs first. Keep transport logging outermost so it observes auth 401s.
         if self.support_project_id_endpoints:
             # this means, dynamically allow endpoints
             # like ../mcp/{project_id}/..  and extract that project id as
             # context var
             app.add_middleware(ProjectIdMiddleware)
+        app.add_middleware(MCPTransportLoggingMiddleware)
 
         # Metrics are now served on a separate port, not mounted here
         return app

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -20,6 +20,7 @@ Tests for JWKSVerifier — JWKS-based JWT verification and claims extraction.
 import logging
 import time
 import pytest
+import structlog
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import jwt as pyjwt
@@ -36,6 +37,7 @@ from starlette.responses import Response
 from dremioai import log
 from dremioai.servers.jwks_verifier import JWKSVerifier, VerifiedClaims, TokenExpiredError
 from dremioai.servers.mcp import (
+    FastMCPServerWithAuthToken,
     MCPTransportLoggingMiddleware,
     Transports,
     init,
@@ -50,6 +52,21 @@ JWKS_DECODE = "dremioai.servers.jwks_verifier.pyjwt.decode"
 def verifier():
     with patch.object(PyJWKClient, "__init__", return_value=None):
         return JWKSVerifier("https://example.com/.well-known/jwks.json")
+
+
+@pytest.fixture(autouse=True)
+def configure_logging():
+    structlog.reset_defaults()
+    log._level = None
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    log.configure(enable_json_logging=False, to_file=False)
+    yield
+    structlog.reset_defaults()
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
 
 
 @pytest.fixture
@@ -244,6 +261,30 @@ class TestTokenExpiryBuffer:
         assert result is None
         warning_messages = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
         assert any("JWKS verify" in msg for msg in warning_messages)
+
+
+class TestStreamableHttpLogging:
+    @pytest.mark.asyncio
+    async def test_run_streamable_http_disables_uvicorn_access_logs(self):
+        server = FastMCPServerWithAuthToken(
+            "test-server",
+            host="127.0.0.1",
+            port=8765,
+            log_level="INFO",
+            stateless_http=True,
+        )
+        server._mock_token_verifier = MagicMock()
+
+        mock_uvicorn_server = MagicMock()
+        mock_uvicorn_server.serve = AsyncMock()
+
+        with patch("dremioai.servers.mcp.uvicorn.Config") as mock_config, patch(
+            "dremioai.servers.mcp.uvicorn.Server", return_value=mock_uvicorn_server
+        ):
+            await server.run_streamable_http_async()
+
+        assert mock_config.call_args.kwargs["access_log"] is False
+        mock_uvicorn_server.serve.assert_awaited_once()
 
 
 class TestDispatchWarning:

--- a/tests/servers/test_jwks_verifier.py
+++ b/tests/servers/test_jwks_verifier.py
@@ -23,6 +23,7 @@ import pytest
 import structlog
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import httpx
 import jwt as pyjwt
 from jwt import PyJWKClient, PyJWKClientError, ExpiredSignatureError
 from mcp.server.lowlevel.server import request_ctx
@@ -422,6 +423,34 @@ class TestStreamableHttpInit:
             )
 
         assert mcp.settings.stateless_http is True
+
+    @pytest.mark.asyncio
+    async def test_transport_logging_wraps_unauthorized_responses(self, caplog):
+        with patch("dremioai.servers.mcp.tools.get_tools", return_value=[]), patch(
+            "dremioai.servers.mcp.tools.get_resources", return_value=[]
+        ):
+            mcp = init(
+                mode=None,
+                transport=Transports.streamable_http,
+                host="127.0.0.1",
+                port=8000,
+                mock=True,
+            )
+
+        app = mcp.streamable_http_app()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            with caplog.at_level(logging.INFO):
+                response = await client.post("/mcp")
+
+        assert response.status_code == 401
+        messages = [str(r.message) for r in caplog.records if r.levelno >= logging.INFO]
+        assert any("Unauthorized request rejected" in msg for msg in messages)
+        assert any(
+            "MCP transport request failed" in msg and "401" in msg for msg in messages
+        )
 
 
 class TestMakeLoggedInvoke:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import io
 import json
 import pytest
 import logging
@@ -166,10 +167,12 @@ class TestLoggerConfiguration:
     def test_stdlib_logs_are_rendered_as_json(self, capsys):
         """Stdlib loggers should share the same JSON formatter pipeline."""
         log.configure(enable_json_logging=True)
+        stream = io.StringIO()
+        logging.getLogger().handlers[0].setStream(stream)
 
         logging.getLogger("uvicorn.access").info("Access log message")
 
-        record = json.loads(capsys.readouterr().err.strip())
+        record = json.loads(stream.getvalue().strip())
         assert record["message"] == "Access log message"
         assert record["logger"] == "uvicorn.access"
         assert record["level"] == "info"
@@ -177,13 +180,15 @@ class TestLoggerConfiguration:
     def test_exception_logs_use_json_stacktrace_field(self, capsys):
         """Exception traces should be serialized into a structured stacktrace field."""
         log.configure(enable_json_logging=True)
+        stream = io.StringIO()
+        logging.getLogger().handlers[0].setStream(stream)
 
         try:
             raise RuntimeError("boom")
         except RuntimeError:
             logging.getLogger("uvicorn.error").exception("Request crashed")
 
-        record = json.loads(capsys.readouterr().err.strip())
+        record = json.loads(stream.getvalue().strip())
         assert record["message"] == "Request crashed"
         assert record["logger"] == "uvicorn.error"
         assert "stacktrace" in record

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -163,6 +163,32 @@ class TestLoggerConfiguration:
         logger.info("Test JSON message", key="value")
         assert structlog.is_configured()
 
+    def test_stdlib_logs_are_rendered_as_json(self, capsys):
+        """Stdlib loggers should share the same JSON formatter pipeline."""
+        log.configure(enable_json_logging=True)
+
+        logging.getLogger("uvicorn.access").info("Access log message")
+
+        record = json.loads(capsys.readouterr().err.strip())
+        assert record["message"] == "Access log message"
+        assert record["logger"] == "uvicorn.access"
+        assert record["level"] == "info"
+
+    def test_exception_logs_use_json_stacktrace_field(self, capsys):
+        """Exception traces should be serialized into a structured stacktrace field."""
+        log.configure(enable_json_logging=True)
+
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            logging.getLogger("uvicorn.error").exception("Request crashed")
+
+        record = json.loads(capsys.readouterr().err.strip())
+        assert record["message"] == "Request crashed"
+        assert record["logger"] == "uvicorn.error"
+        assert "stacktrace" in record
+        assert "RuntimeError: boom" in record["stacktrace"]
+
     def test_configure_with_env_json_logging(self):
         """Test JSON logging enabled via environment variable"""
         with patch.dict(os.environ, {"JSON_LOGGING": "1"}):


### PR DESCRIPTION
## Summary
- document that `FastMCP.run()` reaches the streamable HTTP override via polymorphic dispatch
- disable Uvicorn access logs for the CLI streamable HTTP server path and emit request logs through app middleware instead
- route stdlib/framework logs through a shared structlog `ProcessorFormatter` so JSON logging also captures foreign loggers and exception stack traces

## Testing
- `uv run pytest tests/test_log.py tests/servers/test_jwks_verifier.py -q`

## Jira
- DX-120403