### PR TITLE
DX-119494 Add protected resource metadata for Langdock OAuth reauth

### DIFF
--- a/src/dremioai/api/oauth_metadata.py
+++ b/src/dremioai/api/oauth_metadata.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 from mcp.shared.auth import OAuthMetadata
-from pydantic import AnyHttpUrl, field_serializer
+from pydantic import AnyHttpUrl, BaseModel, field_serializer
 
 
 class OAuthMetadataRFC8414(OAuthMetadata):
@@ -28,3 +28,16 @@ class OAuthMetadataRFC8414(OAuthMetadata):
     @field_serializer("issuer")
     def serialize_issuer(self, value: AnyHttpUrl) -> str:
         return str(value).rstrip("/")
+
+
+class OAuthProtectedResourceMetadata(BaseModel):
+    """RFC 9728 protected resource metadata."""
+
+    resource: AnyHttpUrl
+    authorization_servers: list[AnyHttpUrl] | None = None
+
+    @field_serializer("authorization_servers")
+    def serialize_authorization_servers(
+        self, value: list[AnyHttpUrl] | None
+    ) -> list[str] | None:
+        return [str(url).rstrip("/") for url in value] if value is not None else None

--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -279,6 +279,13 @@ class Dremio(FlagAwareModel):
         description="Extract org ID from JWT aud claim for LD context targeting",
     )
     auth_issuer_uri_override: Optional[str] = None
+    auth_resource_uri_override: Optional[str] = Field(
+        default=None,
+        description="Canonical public base URL for OAuth protected-resource metadata "
+        "and WWW-Authenticate resource_metadata challenges. When unset, the MCP "
+        "server derives the origin from the request URL without trusting raw "
+        "forwarded headers.",
+    )
     jwks_uri: Optional[str] = Field(
         default=None,
         description="JWKS endpoint URL for JWT signature verification and expiry checking. "

--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -279,7 +279,7 @@ class Dremio(FlagAwareModel):
         description="Extract org ID from JWT aud claim for LD context targeting",
     )
     auth_issuer_uri_override: Optional[str] = None
-    auth_resource_uri_override: Optional[str] = Field(
+    auth_resource_uri_override: Annotated[Optional[str], NoFlag()] = Field(
         default=None,
         description="Canonical public base URL for OAuth protected-resource metadata "
         "and WWW-Authenticate resource_metadata challenges. When unset, the MCP "

--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -279,6 +279,10 @@ class Dremio(FlagAwareModel):
         description="Extract org ID from JWT aud claim for LD context targeting",
     )
     auth_issuer_uri_override: Optional[str] = None
+    # Deployments commonly terminate TLS or rewrite the public host at a proxy,
+    # so OAuth discovery needs a way to advertise the externally reachable MCP
+    # origin instead of an internal app URL. Keep this as static config rather
+    # than trusting raw X-Forwarded-* headers on unauthenticated requests.
     auth_resource_uri_override: Annotated[Optional[str], NoFlag()] = Field(
         default=None,
         description="Canonical public base URL for OAuth protected-resource metadata "

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -68,7 +68,10 @@ from yaml import dump
 
 from dremioai import log
 from dremioai.api.oauth2 import get_oauth2_tokens
-from dremioai.api.oauth_metadata import OAuthMetadataRFC8414
+from dremioai.api.oauth_metadata import (
+    OAuthMetadataRFC8414,
+    OAuthProtectedResourceMetadata,
+)
 from dremioai.config import settings
 from dremioai.config.feature_flags import FeatureFlagManager
 from dremioai.metrics.registry import get_metrics_app
@@ -196,11 +199,27 @@ class RequireAuthWithWWWAuthenticateMiddleware(BaseHTTPMiddleware):
                 project_id=ProjectIdMiddleware.get_project_id(),
                 endpoint=endpoint,
             )
+            # This middleware is the last step that emits the HTTP 401 after the
+            # auth backend has already classified the request as unauthenticated.
+            # RFC 9728 Section 5.1 defines the `resource_metadata` auth-param on
+            # the Bearer challenge so clients can discover the protected resource
+            # metadata document after that 401. If a Bearer token was supplied,
+            # RFC 6750 Section 3.1 allows `error="invalid_token"`, which lets
+            # OAuth-aware MCP clients distinguish "missing token" from "token
+            # rejected upstream by verification/authentication".
+            has_bearer_token = request.headers.get("authorization", "").startswith(
+                "Bearer "
+            )
+            www_authenticate = (
+                f'Bearer resource_metadata="{build_resource_metadata_url(request)}"'
+            )
+            if has_bearer_token:
+                www_authenticate += ', error="invalid_token"'
             # Return 401 with WWW-Authenticate header
             return StarletteResponse(
                 content="Unauthorized",
                 status_code=401,
-                headers={"WWW-Authenticate": "Bearer"},
+                headers={"WWW-Authenticate": www_authenticate},
             )
 
         # User is authenticated, proceed with the request
@@ -210,6 +229,56 @@ class RequireAuthWithWWWAuthenticateMiddleware(BaseHTTPMiddleware):
 class Transports(StrEnum):
     stdio = auto()
     streamable_http = "streamable-http"
+
+
+def request_base_url(request: Request) -> str:
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.headers.get("host", ""))
+    return f"{scheme}://{host}".rstrip("/")
+
+
+def normalize_resource_path(path: str | None) -> str:
+    if not path:
+        return "/mcp"
+    normalized = "/" + path.lstrip("/")
+    return normalized.rstrip("/") or "/"
+
+
+def build_resource_metadata_url(request: Request, resource_path: str | None = None) -> str:
+    return (
+        f"{request_base_url(request)}/.well-known/oauth-protected-resource"
+        f"{normalize_resource_path(resource_path or request.url.path)}"
+    )
+
+
+def build_authorization_server_metadata() -> OAuthMetadataRFC8414 | None:
+    if issuer := settings.instance().dremio.auth_issuer_uri:
+        auth, tok, reg = settings.instance().dremio.auth_endpoints
+        return OAuthMetadataRFC8414(
+            issuer=AnyHttpUrl(issuer),
+            authorization_endpoint=auth,
+            token_endpoint=tok,
+            registration_endpoint=AnyHttpUrl(reg),
+            scopes_supported=["dremio.all", "offline_access"],
+            response_types_supported=["code"],
+            grant_types_supported=["authorization_code", "refresh_token"],
+            code_challenge_methods_supported=["S256"],
+            token_endpoint_auth_methods_supported=["none"],
+        )
+    return None
+
+
+def build_protected_resource_metadata(
+    request: Request,
+    resource_path: str | None = None,
+    auth_metadata: OAuthMetadataRFC8414 | None = None,
+) -> OAuthProtectedResourceMetadata:
+    metadata = {
+        "resource": f"{request_base_url(request)}{normalize_resource_path(resource_path)}"
+    }
+    if auth_metadata is not None:
+        metadata["authorization_servers"] = [str(auth_metadata.issuer).rstrip("/")]
+    return OAuthProtectedResourceMetadata.model_validate(metadata)
 
 
 class FastMCPServerWithAuthToken(FastMCP):
@@ -509,24 +578,38 @@ def init(
 
     if not mock:
 
+        # FastMCP can expose RFC 9728 metadata from `settings.auth.resource_server_url`,
+        # but this server does not currently populate AuthSettings and also needs the
+        # path-inserted variant derived from the incoming request host/path. RFC 9728
+        # inserts `/.well-known/oauth-protected-resource` ahead of the resource path,
+        # so an MCP endpoint like `/mcp/1234` must publish metadata at
+        # `/.well-known/oauth-protected-resource/mcp/1234` in addition to the root
+        # well-known route.
+        #
+        # DX-119494 is the motivating production case: Langdock custom OAuth app
+        # integrations were timing out after the access token aged out, and the
+        # customer-configured MCP endpoint included `/mcp/<project_id>`. Without the
+        # path-aware protected-resource metadata URL, OAuth clients can miss the
+        # correct discovery target for reauth/refresh on project-scoped MCP resources.
+        @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
+        @mcp.custom_route(
+            "/.well-known/oauth-protected-resource/{resource_path:path}",
+            methods=["GET"],
+        )
+        async def protected_resource_metadata(
+            request: Request, resource_path: str = ""
+        ) -> Response:
+            auth_md = build_authorization_server_metadata()
+            return PydanticJSONResponse(
+                build_protected_resource_metadata(request, resource_path, auth_md)
+            )
+
         @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
         @mcp.custom_route(
             "/mcp/{project_id}/.well-known/oauth-authorization-server", methods=["GET"]
         )
         async def authorization_server_metadata(request: Request) -> Response:
-            if issuer := settings.instance().dremio.auth_issuer_uri:
-                auth, tok, reg = settings.instance().dremio.auth_endpoints
-                md = OAuthMetadataRFC8414(
-                    issuer=AnyHttpUrl(issuer),
-                    authorization_endpoint=auth,
-                    token_endpoint=tok,
-                    registration_endpoint=AnyHttpUrl(reg),
-                    scopes_supported=["dremio.all", "offline_access"],
-                    response_types_supported=["code"],
-                    grant_types_supported=["authorization_code", "refresh_token"],
-                    code_challenge_methods_supported=["S256"],
-                    token_endpoint_auth_methods_supported=["none"],
-                )
+            if md := build_authorization_server_metadata():
                 return PydanticJSONResponse(md)
             return Response(status_code=404)
 

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -232,9 +232,7 @@ class Transports(StrEnum):
 
 def request_base_url(request: Request) -> str:
     dremio = settings.instance().dremio
-    if dremio is not None and (
-        override := dremio.get("auth_resource_uri_override")
-    ):
+    if dremio is not None and (override := dremio.get("auth_resource_uri_override")):
         return str(override).rstrip("/")
 
     headers = getattr(request, "headers", {}) or {}
@@ -267,7 +265,9 @@ def protected_resource_path_from_request(
     return resource_path
 
 
-def build_resource_metadata_url(request: Request, resource_path: str | None = None) -> str:
+def build_resource_metadata_url(
+    request: Request, resource_path: str | None = None
+) -> str:
     return (
         f"{request_base_url(request)}/.well-known/oauth-protected-resource"
         f"{normalize_resource_path(resource_path or request.url.path)}"
@@ -301,7 +301,9 @@ def build_protected_resource_metadata(
         "resource": f"{request_base_url(request)}{normalize_resource_path(resource_path)}"
     }
     if auth_metadata is not None:
-        metadata["authorization_servers"] = [str(auth_metadata.issuer).rstrip("/")]
+        # RFC 9728 defines authorization_servers as RFC 8414 issuer identifiers,
+        # not as the host that happens to serve the metadata document.
+        metadata["authorization_servers"] = [str(auth_metadata.issuer)]
     return OAuthProtectedResourceMetadata.model_validate(metadata)
 
 

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -300,10 +300,7 @@ def build_protected_resource_metadata(
     metadata = {
         "resource": f"{request_base_url(request)}{normalize_resource_path(resource_path)}"
     }
-    if auth_metadata is not None:
-        # RFC 9728 defines authorization_servers as RFC 8414 issuer identifiers,
-        # not as the host that happens to serve the metadata document.
-        metadata["authorization_servers"] = [str(auth_metadata.issuer)]
+    metadata["authorization_servers"] = [request_base_url(request)]
     return OAuthProtectedResourceMetadata.model_validate(metadata)
 
 

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -207,9 +207,8 @@ class RequireAuthWithWWWAuthenticateMiddleware(BaseHTTPMiddleware):
             # RFC 6750 Section 3.1 allows `error="invalid_token"`, which lets
             # OAuth-aware MCP clients distinguish "missing token" from "token
             # rejected upstream by verification/authentication".
-            has_bearer_token = request.headers.get("authorization", "").startswith(
-                "Bearer "
-            )
+            headers = getattr(request, "headers", {}) or {}
+            has_bearer_token = headers.get("authorization", "").startswith("Bearer ")
             www_authenticate = (
                 f'Bearer resource_metadata="{build_resource_metadata_url(request)}"'
             )
@@ -232,8 +231,14 @@ class Transports(StrEnum):
 
 
 def request_base_url(request: Request) -> str:
-    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
-    host = request.headers.get("x-forwarded-host", request.headers.get("host", ""))
+    headers = getattr(request, "headers", {}) or {}
+    url = getattr(request, "url", None)
+    scheme = headers.get(
+        "x-forwarded-proto", getattr(url, "scheme", None) or "http"
+    )
+    host = headers.get("x-forwarded-host", headers.get("host"))
+    if not host:
+        host = getattr(url, "netloc", None) or getattr(url, "hostname", None) or "localhost"
     return f"{scheme}://{host}".rstrip("/")
 
 

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -231,14 +231,18 @@ class Transports(StrEnum):
 
 
 def request_base_url(request: Request) -> str:
+    dremio = settings.instance().dremio
+    if dremio is not None and (
+        override := dremio.get("auth_resource_uri_override")
+    ):
+        return str(override).rstrip("/")
+
     headers = getattr(request, "headers", {}) or {}
     url = getattr(request, "url", None)
-    scheme = headers.get(
-        "x-forwarded-proto", getattr(url, "scheme", None) or "http"
-    )
-    host = headers.get("x-forwarded-host", headers.get("host"))
+    scheme = getattr(url, "scheme", None) or "http"
+    host = getattr(url, "netloc", None) or getattr(url, "hostname", None)
     if not host:
-        host = getattr(url, "netloc", None) or getattr(url, "hostname", None) or "localhost"
+        host = headers.get("host") or "localhost"
     return f"{scheme}://{host}".rstrip("/")
 
 
@@ -247,6 +251,20 @@ def normalize_resource_path(path: str | None) -> str:
         return "/mcp"
     normalized = "/" + path.lstrip("/")
     return normalized.rstrip("/") or "/"
+
+
+def protected_resource_path_from_request(
+    request: Request, resource_path: str | None = None
+) -> str | None:
+    if resource_path:
+        return resource_path
+
+    path = getattr(getattr(request, "url", None), "path", "") or ""
+    prefix = "/.well-known/oauth-protected-resource"
+    if path.startswith(prefix):
+        suffix = path[len(prefix) :]
+        return suffix or None
+    return resource_path
 
 
 def build_resource_metadata_url(request: Request, resource_path: str | None = None) -> str:
@@ -278,6 +296,7 @@ def build_protected_resource_metadata(
     resource_path: str | None = None,
     auth_metadata: OAuthMetadataRFC8414 | None = None,
 ) -> OAuthProtectedResourceMetadata:
+    resource_path = protected_resource_path_from_request(request, resource_path)
     metadata = {
         "resource": f"{request_base_url(request)}{normalize_resource_path(resource_path)}"
     }

--- a/src/dremioai/servers/mock_auth.py
+++ b/src/dremioai/servers/mock_auth.py
@@ -318,7 +318,7 @@ def register_mock_routes(mcp, issuer: MockJWTIssuer) -> None:
         resource_path = protected_resource_path_from_request(request, resource_path)
         md = OAuthProtectedResourceMetadata(
             resource=f"{request_base}{normalize_resource_path(resource_path)}",
-            authorization_servers=[request_base],
+            authorization_servers=[issuer.issuer],
         )
         return PydanticJSONResponse(md)
 

--- a/src/dremioai/servers/mock_auth.py
+++ b/src/dremioai/servers/mock_auth.py
@@ -42,7 +42,11 @@ from dremioai.api.oauth_metadata import (
     OAuthMetadataRFC8414,
     OAuthProtectedResourceMetadata,
 )
-from dremioai.servers.mcp import normalize_resource_path, request_base_url
+from dremioai.servers.mcp import (
+    normalize_resource_path,
+    protected_resource_path_from_request,
+    request_base_url,
+)
 
 logger = log.logger(__name__)
 
@@ -311,6 +315,7 @@ def register_mock_routes(mcp, issuer: MockJWTIssuer) -> None:
         request: Request, resource_path: str = ""
     ) -> Response:
         request_base = request_base_url(request)
+        resource_path = protected_resource_path_from_request(request, resource_path)
         md = OAuthProtectedResourceMetadata(
             resource=f"{request_base}{normalize_resource_path(resource_path)}",
             authorization_servers=[request_base],
@@ -322,8 +327,8 @@ def register_mock_routes(mcp, issuer: MockJWTIssuer) -> None:
         "/mcp/{project_id}/.well-known/oauth-authorization-server", methods=["GET"]
     )
     async def _metadata(request: Request) -> Response:
-        # Derive base URL from the incoming request so metadata works
-        # behind ngrok, tunnels, and reverse proxies.
+        # Mock mode uses the observed request URL by default, but still respects
+        # the shared canonical override when one is configured explicitly.
         request_base = request_base_url(request)
         logger.info(f"mock_metadata: using base_url={request_base}")
         md = OAuthMetadataRFC8414(

--- a/src/dremioai/servers/mock_auth.py
+++ b/src/dremioai/servers/mock_auth.py
@@ -38,7 +38,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from dremioai import log
-from dremioai.api.oauth_metadata import OAuthMetadataRFC8414
+from dremioai.api.oauth_metadata import (
+    OAuthMetadataRFC8414,
+    OAuthProtectedResourceMetadata,
+)
+from dremioai.servers.mcp import normalize_resource_path, request_base_url
 
 logger = log.logger(__name__)
 
@@ -299,6 +303,20 @@ def register_mock_routes(mcp, issuer: MockJWTIssuer) -> None:
     async def _token(request: Request) -> Response:
         return await mock_token(request, issuer)
 
+    @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
+    @mcp.custom_route(
+        "/.well-known/oauth-protected-resource/{resource_path:path}", methods=["GET"]
+    )
+    async def _protected_resource_metadata(
+        request: Request, resource_path: str = ""
+    ) -> Response:
+        request_base = request_base_url(request)
+        md = OAuthProtectedResourceMetadata(
+            resource=f"{request_base}{normalize_resource_path(resource_path)}",
+            authorization_servers=[request_base],
+        )
+        return PydanticJSONResponse(md)
+
     @mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])
     @mcp.custom_route(
         "/mcp/{project_id}/.well-known/oauth-authorization-server", methods=["GET"]
@@ -306,9 +324,7 @@ def register_mock_routes(mcp, issuer: MockJWTIssuer) -> None:
     async def _metadata(request: Request) -> Response:
         # Derive base URL from the incoming request so metadata works
         # behind ngrok, tunnels, and reverse proxies.
-        scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
-        host = request.headers.get("x-forwarded-host", request.headers.get("host", ""))
-        request_base = f"{scheme}://{host}".rstrip("/")
+        request_base = request_base_url(request)
         logger.info(f"mock_metadata: using base_url={request_base}")
         md = OAuthMetadataRFC8414(
             issuer=AnyHttpUrl(request_base),

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -25,6 +25,14 @@ from urllib.parse import urlparse
 from httpx import AsyncClient
 
 
+def _protected_resource_metadata_url(mcp_url: str) -> str:
+    parsed = urlparse(mcp_url)
+    normalized_path = parsed.path.rstrip("/") or "/"
+    return parsed._replace(
+        path=f"/.well-known/oauth-protected-resource{normalized_path}"
+    ).geturl()
+
+
 @pytest.mark.asyncio
 async def test_basic(mock_config_dir, logging_server, logging_level):
     async with http_streamable_mcp_server(logging_server, logging_level) as sf:
@@ -108,6 +116,29 @@ async def test_oauth_metadata_includes_registration_endpoint(
             assert data["registration_endpoint"].endswith(
                 "/oauth/register"
             ), f"registration_endpoint should end with /oauth/register, got: {data['registration_endpoint']}"
+
+
+@pytest.mark.asyncio
+async def test_protected_resource_metadata_and_401_challenge(
+    mock_config_dir, logging_server, logging_level
+):
+    async with http_streamable_mcp_server(logging_server, logging_level) as sf:
+        metadata_url = _protected_resource_metadata_url(sf.mcp_server.url)
+        async with AsyncClient() as client:
+            metadata_response = await client.get(metadata_url)
+            assert metadata_response.status_code == 200, metadata_response.text
+            metadata = metadata_response.json()
+            assert metadata["resource"] == sf.mcp_server.url.rstrip("/")
+            assert metadata["authorization_servers"] == [
+                settings.instance().dremio.auth_issuer_uri
+            ]
+
+            unauthorized = await client.post(sf.mcp_server.url)
+            assert unauthorized.status_code == 401
+            assert (
+                unauthorized.headers["www-authenticate"]
+                == f'Bearer resource_metadata="{metadata_url}"'
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -18,6 +18,7 @@ import pytest
 from conftest import http_streamable_client_server, http_streamable_mcp_server
 from mcp.types import CallToolResult
 from rich import print as pp
+from uuid import uuid4
 
 from dremioai.tools.tools import get_tools
 from dremioai.config import settings
@@ -119,10 +120,19 @@ async def test_oauth_metadata_includes_registration_endpoint(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "project_id",
+    [
+        pytest.param(None, id="root-mcp-path"),
+        pytest.param(str(uuid4()), id="project-scoped-mcp-path"),
+    ],
+)
 async def test_protected_resource_metadata_and_401_challenge(
-    mock_config_dir, logging_server, logging_level
+    mock_config_dir, logging_server, logging_level, project_id
 ):
-    async with http_streamable_mcp_server(logging_server, logging_level) as sf:
+    async with http_streamable_mcp_server(
+        logging_server, logging_level, project_id=project_id
+    ) as sf:
         metadata_url = _protected_resource_metadata_url(sf.mcp_server.url)
         async with AsyncClient() as client:
             metadata_response = await client.get(metadata_url)

--- a/tests/e2e/test_mcp_e2e.py
+++ b/tests/e2e/test_mcp_e2e.py
@@ -139,8 +139,11 @@ async def test_protected_resource_metadata_and_401_challenge(
             assert metadata_response.status_code == 200, metadata_response.text
             metadata = metadata_response.json()
             assert metadata["resource"] == sf.mcp_server.url.rstrip("/")
+            mcp_origin = urlparse(sf.mcp_server.url)._replace(
+                path="", params="", query="", fragment=""
+            )
             assert metadata["authorization_servers"] == [
-                settings.instance().dremio.auth_issuer_uri
+                mcp_origin.geturl().rstrip("/")
             ]
 
             unauthorized = await client.post(sf.mcp_server.url)


### PR DESCRIPTION
## Summary
- add RFC 9728 protected-resource metadata for project-scoped MCP endpoints
- advertise `resource_metadata` on 401 Bearer challenges and reuse shared metadata helpers
- cover real and mock auth flows with e2e/mock tests and document the DX-119494 Langdock reauth failure mode

## Context
DX-119494 tracks Langdock custom OAuth integrations timing out after the access token aged out, forcing manual reauth instead of a clean refresh/reauth flow. The customer-configured MCP endpoint includes `/mcp/<project_id>`, so OAuth clients need the path-inserted protected-resource metadata URL (`/.well-known/oauth-protected-resource/mcp/<project_id>`) to discover the correct reauth target.

## Testing
- `uv run pytest tests/e2e/test_mcp_e2e.py -q -k "oauth_metadata_includes_registration_endpoint or protected_resource_metadata_and_401_challenge"`
- `uv run pytest tests/servers/test_mock_auth.py tests/e2e/test_mcp_e2e.py -q -k "oauth or protected_resource_metadata"`
