### PR TITLE
DX-122122: Support request-scoped dynamic MCP tools without FastMCP global tool cache

### DIFF
--- a/src/dremioai/api/cli/__main__.py
+++ b/src/dremioai/api/cli/__main__.py
@@ -23,6 +23,7 @@ import asyncio
 from dremioai.log import configure, set_level
 from dremioai.config import settings
 
+from dremioai.api.cli.ai_tools import app as ai_tools_app
 from dremioai.api.cli.engines import app as engines_app
 from dremioai.api.cli.prometheus import app as prometheus_app
 from dremioai.api.cli.search import app as search_app
@@ -51,6 +52,7 @@ app.add_typer(engines_app, callback=common_args)
 app.add_typer(prometheus_app, callback=common_args)
 app.add_typer(search_app, callback=common_args)
 app.add_typer(oauth_app, callback=common_args)
+app.add_typer(ai_tools_app, callback=common_args)
 
 
 @catalog_app.command(name="lineage")

--- a/src/dremioai/api/cli/ai_tools.py
+++ b/src/dremioai/api/cli/ai_tools.py
@@ -1,0 +1,71 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""CLI commands for Dremio remote AI tools."""
+
+import asyncio
+import json
+from typing import Annotated, Optional
+
+from rich import print as pp
+from typer import Argument, Option, Typer
+
+from dremioai.api.dremio import ai_tools
+
+app = Typer(
+    name="ai-tools",
+    help="Interact with remote Dremio AI tools",
+    context_settings=dict(help_option_names=["-h", "--help"]),
+    no_args_is_help=True,
+)
+
+
+@app.command("list")
+def list_tools():
+    """List available remote AI tools from Dremio."""
+    response = asyncio.run(ai_tools.list_tools())
+    if response.error:
+        pp(f"[red]Error:[/red] {response.error}")
+        raise SystemExit(1)
+    if not response.tools:
+        pp("[yellow]No remote tools available.[/yellow]")
+        return
+    for tool in response.tools:
+        pp(f"[bold]{tool.name}[/bold]  {tool.description or ''}")
+
+
+@app.command("call")
+def call_tool(
+    tool_name: Annotated[str, Argument(help="Name of the tool to invoke")],
+    args: Annotated[
+        Optional[str],
+        Option("--args", "-a", help="Tool arguments as a JSON object string"),
+    ] = None,
+):
+    """Invoke a remote AI tool by name."""
+    parsed_args: dict = {}
+    if args:
+        try:
+            parsed_args = json.loads(args)
+        except json.JSONDecodeError as exc:
+            pp(f"[red]Invalid JSON in --args:[/red] {exc}")
+            raise SystemExit(1)
+
+    response = asyncio.run(ai_tools.invoke_tool(tool_name, parsed_args))
+    if response.error:
+        pp(f"[red]Error:[/red] {response.error}")
+        raise SystemExit(1)
+    pp(response.result)

--- a/src/dremioai/api/dremio/ai_tools.py
+++ b/src/dremioai/api/dremio/ai_tools.py
@@ -62,6 +62,75 @@ class InvokeToolResponse(BaseModel):
         return self.result is None and self.error is None
 
 
+# ---------------------------------------------------------------------------
+# Semantic-layer response models
+# ---------------------------------------------------------------------------
+
+class RelationshipUsage(BaseModel):
+    """Historical usage count for a table relationship in a given month."""
+
+    year: str
+    month: str
+    count: int
+
+
+class TableRelationship(BaseModel):
+    """A join relationship between two tables, as returned by ``getTableRelationShips``."""
+
+    source_table_id: str = Field(alias="sourceTableId")
+    source_table_name: str = Field(alias="sourceTableName")
+    source_table_alias: Optional[str] = Field(None, alias="sourceTableAlias")
+    source_column_name: str = Field(alias="sourceColumnName")
+    target_table_id: str = Field(alias="targetTableId")
+    target_table_name: str = Field(alias="targetTableName")
+    target_table_alias: Optional[str] = Field(None, alias="targetTableAlias")
+    target_column_name: str = Field(alias="targetColumnName")
+    join_cardinality: Optional[str] = Field(None, alias="joinCardinality")
+    description: Optional[str] = None
+    usage_metrics: List[RelationshipUsage] = Field(default_factory=list, alias="usageMetrics")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MetricUsage(BaseModel):
+    """Historical usage count for a metric in a given month."""
+
+    year: str
+    month: str
+    count: int
+
+
+class MetricColumn(BaseModel):
+    """A column referenced by a metric's SQL formula."""
+
+    table_name: Optional[str] = Field(None, alias="tableName")
+    column_name: str = Field(alias="columnName")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class Metric(BaseModel):
+    """A semantic-layer metric returned by ``searchMetrics``."""
+
+    name: str
+    description: Optional[str] = None
+    sql_formula: str = Field(alias="sqlFormula")
+    columns: List[MetricColumn] = Field(default_factory=list)
+    synonyms: List[str] = Field(default_factory=list)
+    usage_metrics: List[MetricUsage] = Field(default_factory=list, alias="usageMetrics")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class MetricsSearchResult(BaseModel):
+    """Top-level payload inside ``InvokeToolResponse.result`` for ``searchMetrics``."""
+
+    error_message: Optional[str] = Field(None, alias="errorMessage")
+    metrics: List[Metric] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 async def list_tools() -> ListToolsResponse:
     try:
         client = AsyncHttpClient()
@@ -93,3 +162,24 @@ async def invoke_tool(tool_name: str, args: Dict[str, Any]) -> InvokeToolRespons
     except Exception:
         log.exception("Failed to invoke AI tool '%s'", tool_name)
         return InvokeToolResponse(error=f"Unexpected error invoking tool '{tool_name}'")
+
+
+_SEMANTIC_TOOL_NAMES = frozenset({"searchMetrics", "getTableRelationships"})
+
+
+async def get_semantic_layer_tool_descriptions() -> dict[str, str]:
+    """Return the descriptions for ``searchMetrics`` and ``getTableRelationships``
+    as advertised by Dremio's AI tool registry.
+
+    Used by :class:`SearchTableAndViews` to enrich its own tool description with
+    live, server-supplied text when ``enable_semantic_layer`` is configured.
+    Returns an empty dict when the registry is unavailable or returns an error.
+    """
+    response = await list_tools()
+    if response.error or not response.tools:
+        return {}
+    return {
+        t.name: (t.description or "")
+        for t in response.tools
+        if t.name in _SEMANTIC_TOOL_NAMES
+    }

--- a/src/dremioai/api/dremio/ai_tools.py
+++ b/src/dremioai/api/dremio/ai_tools.py
@@ -20,7 +20,7 @@ from urllib.parse import quote
 
 from aiohttp import ClientResponseError
 from dremioai.api.transport import DremioAsyncHttpClient as AsyncHttpClient
-from dremioai.config import settings
+from dremioai.config import settings, feature_flags
 from dremioai.log import logger
 
 log = logger(__name__)
@@ -42,6 +42,12 @@ class ListToolsResponse(BaseModel):
 
     def __bool__(self):
         return self.error is None
+
+
+def is_semantic_layer_enabled() -> bool:
+    return feature_flags.FeatureFlagManager.instance().get_flag(
+        "ai_semantic_layer.enabled", False
+    ) or settings.instance().dremio.get("enable_semantic_layer")
 
 
 class InvokeToolResponseResult(BaseModel):

--- a/src/dremioai/api/dremio/ai_tools.py
+++ b/src/dremioai/api/dremio/ai_tools.py
@@ -15,7 +15,7 @@
 #
 
 from pydantic import BaseModel, Field, ConfigDict
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, TypeVar
 from urllib.parse import quote
 
 from aiohttp import ClientResponseError
@@ -44,9 +44,38 @@ class ListToolsResponse(BaseModel):
         return self.error is None
 
 
+class InvokeToolResponseResult(BaseModel):
+    """Wraps the ``result`` object returned by an AI-tool invocation.
+
+    Extra fields from the server (e.g. ``columns``, ``rows``) are stored in
+    ``model_extra`` and exposed via dict-style access so callers can write
+    ``response.result["columns"]`` without changing their code.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    # Inner-result level error (Java uses "errorMessage" here)
+    error: Optional[str] = Field(default=None, alias="errorMessage")
+
+    def __bool__(self) -> bool:
+        return self.error is None
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow dict-style read access to extra fields: ``result["columns"]``."""
+        if key in self.__class__.model_fields:
+            return getattr(self, key)
+        return self.model_extra[key]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, dict):
+            return self.model_extra == other
+        return super().__eq__(other)
+
+
 class InvokeToolResponse(BaseModel):
 
-    result: Optional[Any] = None
+    result: Optional[InvokeToolResponseResult] = None
+    # Top-level error key from Dremio is "error" (not "errorMessage")
     error: Optional[str] = None
 
     def __bool__(self):
@@ -65,6 +94,7 @@ class InvokeToolResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Semantic-layer response models
 # ---------------------------------------------------------------------------
+
 
 class RelationshipUsage(BaseModel):
     """Historical usage count for a table relationship in a given month."""
@@ -87,9 +117,25 @@ class TableRelationship(BaseModel):
     target_column_name: str = Field(alias="targetColumnName")
     join_cardinality: Optional[str] = Field(None, alias="joinCardinality")
     description: Optional[str] = None
-    usage_metrics: List[RelationshipUsage] = Field(default_factory=list, alias="usageMetrics")
+    usage_metrics: List[RelationshipUsage] = Field(
+        default_factory=list, alias="usageMetrics"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class TableRelationshipsResponse(BaseModel):
+    relationships: Optional[List[TableRelationship]] = Field(default_factory=list)
+    error: Optional[str] = Field(None, alias="errorMessage")
+
+    def __bool__(self):
+        return self.error is None
+
+    @property
+    def is_empty(self) -> bool:
+        return self.error is None and (
+            self.relationships is None or len(self.relationships) == 0
+        )
 
 
 class MetricUsage(BaseModel):
@@ -125,8 +171,15 @@ class Metric(BaseModel):
 class MetricsSearchResult(BaseModel):
     """Top-level payload inside ``InvokeToolResponse.result`` for ``searchMetrics``."""
 
-    error_message: Optional[str] = Field(None, alias="errorMessage")
+    error: Optional[str] = Field(None, alias="errorMessage")
     metrics: List[Metric] = Field(default_factory=list)
+
+    def __bool__(self):
+        return self.error is None
+
+    @property
+    def is_empty(self) -> bool:
+        return self.error is None and (self.metrics is None or len(self.metrics) == 0)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -162,6 +215,36 @@ async def invoke_tool(tool_name: str, args: Dict[str, Any]) -> InvokeToolRespons
     except Exception:
         log.exception("Failed to invoke AI tool '%s'", tool_name)
         return InvokeToolResponse(error=f"Unexpected error invoking tool '{tool_name}'")
+
+
+DeserT = TypeVar("DeserT", bound=BaseModel)
+
+
+async def invoke_tool_with_deser(
+    tool_name: str, args: Dict[str, Any], deser: DeserT
+) -> Optional[List[DeserT]]:
+    if resp := await invoke_tool(tool_name, args):
+        if resp.is_empty:
+            return []
+        try:
+            return deser.model_validate(resp.result.model_extra)
+        except:
+            log.exception(f"Failed to process {tool_name} ({args})")
+    else:
+        log.error(f"Failed {tool_name} for {args}: {resp}")
+    return None
+
+
+async def get_relationships(path: List[str]) -> Optional[TableRelationshipsResponse]:
+    return await invoke_tool_with_deser(
+        "getTableRelationships", {"path": path}, TableRelationshipsResponse
+    )
+
+
+async def get_metrics(query: str) -> Optional[List[Metric]]:
+    return await invoke_tool_with_deser(
+        "searchMetrics", {"query": query}, MetricsSearchResult
+    )
 
 
 _SEMANTIC_TOOL_NAMES = frozenset({"searchMetrics", "getTableRelationships"})

--- a/src/dremioai/api/dremio/search.py
+++ b/src/dremioai/api/dremio/search.py
@@ -25,7 +25,8 @@ from typing import (
     Any,
     List,
     Union,
-    Optional, Dict,
+    Optional,
+    Dict,
 )
 from dremioai.api.util import UStrEnum
 from datetime import datetime
@@ -161,16 +162,19 @@ class EnterpriseSearchCatalogObject(BaseModel):
     modified_at: Optional[datetime] = Field(default=None, alias="lastModifiedAt")
     func_sql: Optional[str] = Field(default=None, alias="functionSql")
     owner: Optional[EnterpriseSearchUserOrRoleObject] = None
-    schema: Optional[Dict[str, Any]] = None
+    dremio_schema: Optional[Dict[str, Any]] = Field(default=None, alias="schema")
 
     async def populate_schemas(self):
         if self.path:
             try:
-                data = await get_schema(dataset_path_or_id=self.path, include_tags=True, flatten=True)
-                self.schema = data.get('schema') if data else None
+                data = await get_schema(
+                    dataset_path_or_id=self.path, include_tags=True, flatten=True
+                )
+                self.dremio_schema = data.get("schema") if data else None
             except Exception as e:
-                logger.error("Schema not found for search",
-                             path=self.path, reason=str(e))
+                logger.error(
+                    "Schema not found for search", path=self.path, reason=str(e)
+                )
 
     def as_df_dict(self):
         return {
@@ -179,7 +183,7 @@ class EnterpriseSearchCatalogObject(BaseModel):
             "type": self.type,
             "tags": ",".join(self.labels),
             "description": self.wiki,
-            "schema": self.schema,
+            "schema": self.dremio_schema,
         }
 
 
@@ -231,8 +235,9 @@ class EnterpriseSearchResultsWrapper(BaseModel):
 
 
 async def get_search_results(
-    search: str | Search, use_df: bool = False,
-    remove_catalog_name: Optional[bool] = True
+    search: str | Search,
+    use_df: bool = False,
+    remove_catalog_name: Optional[bool] = True,
 ) -> EnterpriseSearchResultsWrapper | pd.DataFrame:
     if isinstance(search, str):
         search = Search(query=search)
@@ -253,9 +258,19 @@ async def get_search_results(
         deser=EnterpriseSearchResults,
         params=params,
     )
-    while response.results and response.error is None and response.more is None:
-        result.extend(response.results)
-        if response.next_page_token is None:
+    while (
+        response.results
+        and response.error is None
+        and response.more is None
+        and len(result) <= search.max_results
+    ):
+        rem = abs(len(result) - search.max_results)
+        result.extend(
+            r
+            for r in response.results[:rem]
+            if r.category in (Category.TABLE, Category.VIEW)
+        )
+        if response.next_page_token is None or len(result) >= search.max_results:
             break
         search.next_page_token = response.next_page_token
         response = await client.post(
@@ -264,7 +279,7 @@ async def get_search_results(
             deser=EnterpriseSearchResults,
             params=params,
         )
-    result = [r for r in result if r.category in (Category.TABLE, Category.VIEW)]
+    # result = [r for r in result if r.category in (Category.TABLE, Category.VIEW)]
     tasks = [r.catalog.populate_schemas() for r in result]
     await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -324,7 +324,7 @@ class Dremio(FlagAwareModel):
         ),
     )
     search_topN: Annotated[Optional[int], RuntimeMutable()] = Field(
-        default=50,
+        default=10,
         description="Server-side upper limit on the number of TABLE/VIEW results returned by SearchTableAndViews.",
     )
 

--- a/src/dremioai/config/settings.py
+++ b/src/dremioai/config/settings.py
@@ -315,6 +315,18 @@ class Dremio(FlagAwareModel):
         default=False,
         description="Enable dynamic registration of remote tools from Dremio's Java-side tool registry",
     )
+    enable_semantic_layer: Annotated[Optional[bool], RuntimeMutable()] = Field(
+        default=False,
+        description=(
+            "Enable semantic layer enrichment in SearchTableAndViews: calls getTableRelationShips "
+            "on results and searchMetrics in parallel, and exposes SearchMetrics / "
+            "GetTableRelationships as standalone MCP tools."
+        ),
+    )
+    search_topN: Annotated[Optional[int], RuntimeMutable()] = Field(
+        default=50,
+        description="Server-side upper limit on the number of TABLE/VIEW results returned by SearchTableAndViews.",
+    )
 
     @field_serializer("raw_pat")
     def serialize_pat(self, pat: str):

--- a/src/dremioai/config/tools.py
+++ b/src/dremioai/config/tools.py
@@ -28,3 +28,6 @@ class ToolType(IntFlag):
     EXPERIMENTAL = (
         auto()
     )  # any experimental tools that are not yet ready for production
+    DYNAMIC_REMOTE_TOOLS = (
+        auto()
+    )  # DiscoverDynamicTools / CallDynamicTool — generic remote tool passthrough; enabled only when explicitly requested

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -628,7 +628,7 @@ def init(
                 else make_logged_invoke(tool.__name__, tool_instance.invoke)
             ),
             name=tool.__name__,
-            description=tool_instance.invoke.__doc__,
+            description=tool_instance.get_description(),
             annotations=ToolAnnotations(
                 readOnlyHint=not (is_sql_tool and allow_dml),
                 destructiveHint=bool(is_sql_tool and allow_dml),

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -50,7 +50,7 @@ from mcp.server.streamable_http import (
     MCP_PROTOCOL_VERSION_HEADER,
     MCP_SESSION_ID_HEADER,
 )
-from mcp.types import ToolAnnotations
+from mcp.types import ContentBlock, Tool as MCPTool, ToolAnnotations
 from pydantic import AnyHttpUrl
 from pydantic.networks import AnyUrl
 from rich import console, table
@@ -67,6 +67,7 @@ from typer import Argument, BadParameter, Option, Typer
 from yaml import dump
 
 from dremioai import log
+from dremioai.api.dremio import ai_tools
 from dremioai.api.oauth2 import get_oauth2_tokens
 from dremioai.api.oauth_metadata import (
     OAuthMetadataRFC8414,
@@ -78,7 +79,7 @@ from dremioai.metrics.registry import get_metrics_app
 from dremioai.metrics.tool_metrics import invocation_counter, invocation_duration
 from dremioai.servers.jwks_verifier import JWKSVerifier, TokenExpiredError
 from dremioai.tools import tools
-from dremioai.tools.tools import ProjectIdMiddleware
+from dremioai.tools.tools import ProjectIdMiddleware, secured
 
 
 class MCPTransportLoggingMiddleware:
@@ -305,6 +306,8 @@ def build_protected_resource_metadata(
 
 
 class FastMCPServerWithAuthToken(FastMCP):
+    _logger = log.logger("FastMCPServerWithAuthToken")
+
     class DelegatingTokenVerifier(TokenVerifier):
         logger = log.logger("DelegatingTokenVerifier")
 
@@ -390,6 +393,55 @@ class FastMCPServerWithAuthToken(FastMCP):
                 scopes=["read"],
                 expires_at=expires_at,
             )
+
+    @secured
+    async def _list_remote_tools(self) -> "ai_tools.ListToolsResponse":
+        return await ai_tools.list_tools()
+
+    @secured
+    async def _invoke_remote_tool(self, tool_name: str, args: Dict[str, Any]) -> "ai_tools.InvokeToolResponse":
+        return await ai_tools.invoke_tool(tool_name, args)
+
+    async def list_tools(self) -> list[MCPTool]:
+        static_tools = await super().list_tools()
+        if not settings.instance().dremio.get("enable_remote_tools"):
+            return static_tools
+        try:
+            response = await self._list_remote_tools()
+            if response.error:
+                self._logger.warning("remote tool listing failed", error=response.error)
+                return static_tools
+            static_names = {t.name for t in static_tools}
+            remote_tools = []
+            for rt in response.tools:
+                if rt.name in static_names:
+                    self._logger.warning(
+                        "remote tool name collides with static tool, skipping",
+                        name=rt.name,
+                    )
+                    continue
+                remote_tools.append(
+                    MCPTool(
+                        name=rt.name,
+                        description=rt.description,
+                        inputSchema=rt.input_schema,
+                    )
+                )
+            return static_tools + remote_tools
+        except Exception:
+            self._logger.exception("error fetching remote tools")
+            return static_tools
+
+    async def call_tool(self, name: str, arguments: dict) -> list[ContentBlock] | dict[str, Any]:
+        static_names = {t.name for t in await super().list_tools()}
+        if name in static_names:
+            return await super().call_tool(name, arguments)
+
+        if not settings.instance().dremio.get("enable_remote_tools"):
+            return {"error": f"Tool '{name}' not found (remote tools disabled)"}
+
+        result = await self._invoke_remote_tool(name, arguments)
+        return result.model_dump(exclude_none=True)
 
     def streamable_http_app(self):
         if self._mock_token_verifier is not None:

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -404,6 +404,26 @@ class FastMCPServerWithAuthToken(FastMCP):
 
     async def list_tools(self) -> list[MCPTool]:
         static_tools = await super().list_tools()
+
+        # Refresh descriptions for tools that advertise dynamic_description=True.
+        # This is done per-request so the LLM always sees up-to-date server text
+        # (e.g. SearchTableAndViews embeds live semantic-layer tool descriptions).
+        if self._dynamic_description_tools:
+            refreshed = []
+            for t in static_tools:
+                if t.name in self._dynamic_description_tools:
+                    try:
+                        new_desc = await self._dynamic_description_tools[t.name].get_description()
+                        refreshed.append(t.model_copy(update={"description": new_desc}))
+                    except Exception:
+                        self._logger.exception(
+                            "failed to refresh description for tool", tool=t.name
+                        )
+                        refreshed.append(t)
+                else:
+                    refreshed.append(t)
+            static_tools = refreshed
+
         if not settings.instance().dremio.get("enable_remote_tools"):
             return static_tools
         try:
@@ -491,6 +511,10 @@ class FastMCPServerWithAuthToken(FastMCP):
         super().__init__(*args, **kwargs)
         self.support_project_id_endpoints = False
         self._mock_token_verifier = None
+        # Populated by init(): tool name → Tools instance for tools that carry
+        # dynamic_description=True.  list_tools() refreshes their descriptions
+        # per-request so the LLM always sees live server-side text.
+        self._dynamic_description_tools: Dict[str, "tools.Tools"] = {}
 
 
 def _make_mock_invoke(tool_class_name: str, original_doc: str):
@@ -628,12 +652,17 @@ def init(
                 else make_logged_invoke(tool.__name__, tool_instance.invoke)
             ),
             name=tool.__name__,
-            description=tool_instance.get_description(),
+            # Use the static docstring at init time.  Tools with
+            # dynamic_description=True have their descriptions refreshed per-
+            # request inside list_tools() using the live server-side text.
+            description=tool_instance.invoke.__doc__ or "",
             annotations=ToolAnnotations(
                 readOnlyHint=not (is_sql_tool and allow_dml),
                 destructiveHint=bool(is_sql_tool and allow_dml),
             ),
         )
+        if tool_instance.dynamic_description and isinstance(mcp, FastMCPServerWithAuthToken):
+            mcp._dynamic_description_tools[tool.__name__] = tool_instance
 
     for resource in tools.get_resources(For=mode):
         resource_instance = resource()

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -43,6 +43,7 @@ from mcp.server.auth.middleware.auth_context import (
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.fastmcp.prompts import Prompt
 from mcp.server.fastmcp.resources import FunctionResource
 from mcp.server.lowlevel.server import request_ctx
@@ -469,10 +470,12 @@ class FastMCPServerWithAuthToken(FastMCP):
         if name in static_names:
             return await super().call_tool(name, arguments)
 
-        if not settings.instance().dremio.get("enable_remote_tools"):
-            return {"error": f"Tool '{name}' not found (remote tools disabled)"}
+        if not self.expose_remote_tools():
+            raise ToolError(f"Tool '{name}' not found (remote tools not enabled)")
 
         result = await self._invoke_remote_tool(name, arguments)
+        if result.error:
+            raise ToolError(result.error)
         return result.model_dump(exclude_none=True)
 
     def streamable_http_app(self):

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -399,8 +399,16 @@ class FastMCPServerWithAuthToken(FastMCP):
         return await ai_tools.list_tools()
 
     @secured
-    async def _invoke_remote_tool(self, tool_name: str, args: Dict[str, Any]) -> "ai_tools.InvokeToolResponse":
+    async def _invoke_remote_tool(
+        self, tool_name: str, args: Dict[str, Any]
+    ) -> "ai_tools.InvokeToolResponse":
         return await ai_tools.invoke_tool(tool_name, args)
+
+    def expose_remote_tools(self) -> bool:
+        if not settings.instance().dremio.get("enable_remote_tools"):
+            return False
+        mode = settings.instance().tools.server_mode
+        return mode & tools.ToolType.DYNAMIC_REMOTE_TOOLS != 0
 
     async def list_tools(self) -> list[MCPTool]:
         static_tools = await super().list_tools()
@@ -413,7 +421,9 @@ class FastMCPServerWithAuthToken(FastMCP):
             for t in static_tools:
                 if t.name in self._dynamic_description_tools:
                     try:
-                        new_desc = await self._dynamic_description_tools[t.name].get_description()
+                        new_desc = await self._dynamic_description_tools[
+                            t.name
+                        ].get_description()
                         refreshed.append(t.model_copy(update={"description": new_desc}))
                     except Exception:
                         self._logger.exception(
@@ -424,7 +434,7 @@ class FastMCPServerWithAuthToken(FastMCP):
                     refreshed.append(t)
             static_tools = refreshed
 
-        if not settings.instance().dremio.get("enable_remote_tools"):
+        if not self.expose_remote_tools():
             return static_tools
         try:
             response = await self._list_remote_tools()
@@ -452,7 +462,9 @@ class FastMCPServerWithAuthToken(FastMCP):
             self._logger.exception("error fetching remote tools")
             return static_tools
 
-    async def call_tool(self, name: str, arguments: dict) -> list[ContentBlock] | dict[str, Any]:
+    async def call_tool(
+        self, name: str, arguments: dict
+    ) -> list[ContentBlock] | dict[str, Any]:
         static_names = {t.name for t in await super().list_tools()}
         if name in static_names:
             return await super().call_tool(name, arguments)
@@ -661,7 +673,9 @@ def init(
                 destructiveHint=bool(is_sql_tool and allow_dml),
             ),
         )
-        if tool_instance.dynamic_description and isinstance(mcp, FastMCPServerWithAuthToken):
+        if tool_instance.dynamic_description and isinstance(
+            mcp, FastMCPServerWithAuthToken
+        ):
             mcp._dynamic_description_tools[tool.__name__] = tool_instance
 
     for resource in tools.get_resources(For=mode):

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -108,6 +108,15 @@ class Tools:
     async def invoke(self):
         raise NotImplementedError("Subclasses should implement this method")
 
+    def get_description(self) -> str:
+        """Return the description for this tool.
+
+        Override in subclasses that need to generate a description dynamically
+        (e.g. based on runtime feature-flag state).  The default implementation
+        returns the raw docstring of the ``invoke`` method.
+        """
+        return type(self).__dict__.get("invoke", None).__doc__ or ""
+
 
 def _json_safe_value(value: Any) -> Any:
     if value is None or value is pd.NA or value is pd.NaT:
@@ -515,34 +524,160 @@ class SearchTableAndViews(Tools):
         ]
     ]
 
+    _SEMANTIC_LAYER_ADDENDUM = """
+
+When ``enable_semantic_layer`` is configured, this tool additionally:
+- Enriches each result with relationship metadata by calling the ``getTableRelationShips``
+  remote tool in parallel across all found tables/views.
+- Searches for relevant metrics via the ``searchMetrics`` remote tool; metric results are
+  included in the returned list with ``"result_type": "METRIC"`` set.
+
+The search is not exhaustive.  The ``topN`` parameter (default 10) controls how many
+TABLE/VIEW results are returned.  The server-side upper limit is set by
+``dremio.search_topN`` (default 50)."""
+
+    def get_description(self) -> str:
+        base = type(self).__dict__["invoke"].__doc__ or ""
+        if settings.instance().dremio.get("enable_semantic_layer"):
+            return base + self._SEMANTIC_LAYER_ADDENDUM
+        return base
+
+    @secured
+    @with_metrics
+    async def invoke(self, query: str, topN: int = 10) -> Dict[str, Any]:
+        """Runs a semantic search on the Dremio cluster to find tables and views that match
+        the query.  This is not an exhaustive search; at most ``topN`` results are returned
+        (default 10, capped by the server-side ``dremio.search_topN`` setting).
+
+        Args:
+            query: The search query describing the data you are looking for.
+            topN: Maximum number of TABLE/VIEW results to return (default 10).
+
+        Returns:
+            A dict with a "results" key containing a list of objects that describe the found
+            tables, views, and (when semantic layer is enabled) metrics.  Each TABLE/VIEW
+            object has "name", "type", "tags", "description", "schema", and optionally
+            "relationships" keys.  Metric objects carry a "result_type" key set to "METRIC".
+            The schema is included so you can avoid a separate GetSchemaOfTable call.
+        """
+        cfg = settings.instance().dremio
+        search_topN = cfg.get("search_topN")
+        max_results = min(topN, search_topN if search_topN is not None else 50)
+        enable_semantic = bool(cfg.get("enable_semantic_layer"))
+
+        search_tasks = [
+            search.get_search_results(
+                search.Search(query=query, filter=category, max_results=max_results),
+                use_df=True,
+            )
+            for category in (search.Category.TABLE, search.Category.VIEW)
+        ]
+
+        if enable_semantic:
+            all_results = await run_in_parallel(
+                search_tasks + [ai_tools.invoke_tool("searchMetrics", {"query": query})]
+            )
+            table_df, view_df = all_results[0], all_results[1]
+            metric_response = all_results[2]
+        else:
+            table_df, view_df = await run_in_parallel(search_tasks)
+            metric_response = None
+
+        frames = [df for df in (table_df, view_df) if not df.empty]
+        records: List[Dict[str, Any]] = (
+            _df_to_json_records(pd.concat(frames)) if frames else []
+        )
+
+        if enable_semantic and records:
+            rel_responses = await run_in_parallel(
+                [
+                    ai_tools.invoke_tool("getTableRelationShips", {"path": r["path"]})
+                    for r in records
+                    if r.get("path")
+                ]
+            )
+            rel_iter = iter(rel_responses)
+            for r in records:
+                if r.get("path"):
+                    resp = next(rel_iter)
+                    if resp and not resp.error:
+                        r["relationships"] = resp.result
+
+        results: List[Dict[str, Any]] = records
+
+        if enable_semantic and metric_response and not metric_response.error:
+            raw = metric_response.result
+            if isinstance(raw, list):
+                metric_items = raw
+            elif isinstance(raw, dict):
+                metric_items = raw.get("metrics") or raw.get("results") or [raw]
+            else:
+                metric_items = []
+            results = results + [{"result_type": "METRIC", **m} for m in metric_items]
+
+        return {"results": results}
+
+
+class SearchMetrics(Tools):
+    """Search for metrics in the Dremio semantic layer using a natural-language query."""
+
+    For: ClassVar[
+        Annotated[ToolType, ToolType.FOR_DATA_PATTERNS | ToolType.EXPERIMENTAL]
+    ]
+
     @secured
     @with_metrics
     async def invoke(self, query: str) -> Dict[str, Any]:
-        """Runs a semantic search on the Dremio cluster to find tables and views that match the query.
+        """Search for metrics in the Dremio semantic layer that match a natural-language query.
+
+        Requires ``enable_semantic_layer`` to be configured.  Returns an empty result when
+        the feature is not enabled.
 
         Args:
-            query: The query to run
+            query: Natural-language description of the metrics you are looking for.
 
         Returns:
-            A dict with "results" key that is a list of objects that describe the found tables and views.
-            Each object has "name", "type" (TABLE or VIEW), "tags", "description" keys, along with "schema"
-            key that lists the entire schema of the table or view. You can rely on this schema and avoid
-            calling GetSchemaOfTable tool.
+            A dict with the metric search results from the Dremio semantic layer.
         """
-        res = await run_in_parallel(
-            [
-                search.get_search_results(
-                    search.Search(query=query, filter=category), use_df=True
-                )
-                for category in (search.Category.TABLE, search.Category.VIEW)
-            ]
-        )
-        res = pd.concat(res)
-        return {"results": res.to_dict(orient="records")}
+        if not settings.instance().dremio.get("enable_semantic_layer"):
+            return {"error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."}
+        result = await ai_tools.invoke_tool("searchMetrics", {"query": query})
+        if result.error:
+            return {"error": result.error}
+        return result.result if isinstance(result.result, dict) else {"results": result.result}
+
+
+class GetTableRelationships(Tools):
+    """Retrieve relationship metadata for a table or view from the Dremio semantic layer."""
+
+    For: ClassVar[
+        Annotated[ToolType, ToolType.FOR_DATA_PATTERNS | ToolType.EXPERIMENTAL]
+    ]
+
+    @secured
+    @with_metrics
+    async def invoke(self, path: List[str]) -> Dict[str, Any]:
+        """Retrieve relationship metadata for a table or view in the Dremio semantic layer.
+
+        Requires ``enable_semantic_layer`` to be configured.
+
+        Args:
+            path: The fully-qualified path of the table or view as a list of name components,
+                  e.g. ``["Samples", "my_schema", "my_table"]``.
+
+        Returns:
+            A dict describing the relationships of the specified table or view.
+        """
+        if not settings.instance().dremio.get("enable_semantic_layer"):
+            return {"error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."}
+        result = await ai_tools.invoke_tool("getTableRelationShips", {"path": path})
+        if result.error:
+            return {"error": result.error}
+        return result.result if isinstance(result.result, dict) else {"result": result.result}
 
 
 class DiscoverDynamicTools(Tools):
-    For: ClassVar[Annotated[ToolType, ToolType.FOR_SELF | ToolType.FOR_DATA_PATTERNS]]
+    For: ClassVar[Annotated[ToolType, ToolType.DYNAMIC_REMOTE_TOOLS]]
 
     @secured
     @with_metrics
@@ -557,7 +692,7 @@ class DiscoverDynamicTools(Tools):
 
 
 class CallDynamicTool(Tools):
-    For: ClassVar[Annotated[ToolType, ToolType.FOR_SELF | ToolType.FOR_DATA_PATTERNS]]
+    For: ClassVar[Annotated[ToolType, ToolType.DYNAMIC_REMOTE_TOOLS]]
 
     @secured
     @with_metrics

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -105,15 +105,20 @@ class Tool:
 
 
 class Tools:
+    # Set to True in subclasses whose description should be refreshed on every
+    # list_tools() call (e.g. because it embeds live server-side information).
+    dynamic_description: ClassVar[bool] = False
+
     async def invoke(self):
         raise NotImplementedError("Subclasses should implement this method")
 
-    def get_description(self) -> str:
+    async def get_description(self) -> str:
         """Return the description for this tool.
 
         Override in subclasses that need to generate a description dynamically
-        (e.g. based on runtime feature-flag state).  The default implementation
-        returns the raw docstring of the ``invoke`` method.
+        at list_tools() time (e.g. based on live server data or feature-flag
+        state).  The default implementation returns the raw docstring of the
+        ``invoke`` method and is never called during server init.
         """
         return type(self).__dict__.get("invoke", None).__doc__ or ""
 
@@ -523,18 +528,14 @@ class SearchTableAndViews(Tools):
             ToolType.FOR_SELF | ToolType.FOR_DATA_PATTERNS | ToolType.EXPERIMENTAL,
         ]
     ]
+    dynamic_description: ClassVar[bool] = True
 
-    def get_description(self) -> str:
-        import asyncio
-
+    @secured
+    async def get_description(self) -> str:
         base = type(self).__dict__["invoke"].__doc__ or ""
         if not settings.instance().dremio.get("enable_semantic_layer"):
             return base
-        try:
-            descriptions = asyncio.run(ai_tools.get_semantic_layer_tool_descriptions())
-        except RuntimeError:
-            # Already inside a running event loop (e.g. called at request time)
-            descriptions = {}
+        descriptions = await ai_tools.get_semantic_layer_tool_descriptions()
         parts = [base, "\nWhen semantic layer is enabled, this tool additionally enriches results:"]
         if sm_desc := descriptions.get("searchMetrics"):
             parts.append(f"- **searchMetrics**: {sm_desc}")

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -524,34 +524,40 @@ class SearchTableAndViews(Tools):
         ]
     ]
 
-    _SEMANTIC_LAYER_ADDENDUM = """
-
-When ``enable_semantic_layer`` is configured, this tool additionally:
-- Enriches each result with relationship metadata by calling the ``getTableRelationShips``
-  remote tool in parallel across all found tables/views.
-- Searches for relevant metrics via the ``searchMetrics`` remote tool; metric results are
-  included in the returned list with ``"result_type": "METRIC"`` set.
-
-The search is not exhaustive.  The ``topN`` parameter (default 10) controls how many
-TABLE/VIEW results are returned.  The server-side upper limit is set by
-``dremio.search_topN`` (default 50)."""
-
     def get_description(self) -> str:
+        import asyncio
+
         base = type(self).__dict__["invoke"].__doc__ or ""
-        if settings.instance().dremio.get("enable_semantic_layer"):
-            return base + self._SEMANTIC_LAYER_ADDENDUM
-        return base
+        if not settings.instance().dremio.get("enable_semantic_layer"):
+            return base
+        try:
+            descriptions = asyncio.run(ai_tools.get_semantic_layer_tool_descriptions())
+        except RuntimeError:
+            # Already inside a running event loop (e.g. called at request time)
+            descriptions = {}
+        parts = [base, "\nWhen semantic layer is enabled, this tool additionally enriches results:"]
+        if sm_desc := descriptions.get("searchMetrics"):
+            parts.append(f"- **searchMetrics**: {sm_desc}")
+        if rel_desc := descriptions.get("getTableRelationships"):
+            parts.append(f"- **getTableRelationships**: {rel_desc}")
+        parts.append(
+            "\nMetric results are included with \"result_type\": \"METRIC\"."
+            " TABLE/VIEW results include a \"relationships\" key when relationship data is available."
+            " The search returns at most topN results (default set by dremio.search_topN)."
+        )
+        return "\n".join(parts)
 
     @secured
     @with_metrics
-    async def invoke(self, query: str, topN: int = 10) -> Dict[str, Any]:
+    async def invoke(self, query: str, topN: Optional[int] = None) -> Dict[str, Any]:
         """Runs a semantic search on the Dremio cluster to find tables and views that match
         the query.  This is not an exhaustive search; at most ``topN`` results are returned
-        (default 10, capped by the server-side ``dremio.search_topN`` setting).
+        (defaults to the server-side ``dremio.search_topN`` setting, which defaults to 10).
 
         Args:
             query: The search query describing the data you are looking for.
-            topN: Maximum number of TABLE/VIEW results to return (default 10).
+            topN: Maximum number of TABLE/VIEW results to return.  Defaults to the
+                  server-side ``dremio.search_topN`` limit.  Cannot exceed that limit.
 
         Returns:
             A dict with a "results" key containing a list of objects that describe the found
@@ -561,8 +567,8 @@ TABLE/VIEW results are returned.  The server-side upper limit is set by
             The schema is included so you can avoid a separate GetSchemaOfTable call.
         """
         cfg = settings.instance().dremio
-        search_topN = cfg.get("search_topN")
-        max_results = min(topN, search_topN if search_topN is not None else 50)
+        server_limit: int = cfg.get("search_topN") or 10
+        max_results = min(topN, server_limit) if topN is not None else server_limit
         enable_semantic = bool(cfg.get("enable_semantic_layer"))
 
         search_tasks = [
@@ -600,20 +606,42 @@ TABLE/VIEW results are returned.  The server-side upper limit is set by
             for r in records:
                 if r.get("path"):
                     resp = next(rel_iter)
-                    if resp and not resp.error:
-                        r["relationships"] = resp.result
+                    if resp and not resp.error and resp.result:
+                        try:
+                            rels = [
+                                ai_tools.TableRelationship.model_validate(item)
+                                for item in resp.result
+                            ]
+                            r["relationships"] = [
+                                rel.model_dump(by_alias=False, exclude_none=True)
+                                for rel in rels
+                            ]
+                        except Exception:
+                            logger.exception("Failed to parse TableRelationship response")
+                            r["relationships"] = resp.result  # fallback to raw
 
         results: List[Dict[str, Any]] = records
 
         if enable_semantic and metric_response and not metric_response.error:
             raw = metric_response.result
-            if isinstance(raw, list):
-                metric_items = raw
-            elif isinstance(raw, dict):
-                metric_items = raw.get("metrics") or raw.get("results") or [raw]
-            else:
-                metric_items = []
-            results = results + [{"result_type": "METRIC", **m} for m in metric_items]
+            if isinstance(raw, dict):
+                try:
+                    metrics_result = ai_tools.MetricsSearchResult.model_validate(raw)
+                    if metrics_result.error_message:
+                        logger.warning(
+                            "searchMetrics returned an error",
+                            error=metrics_result.error_message,
+                        )
+                    else:
+                        results = results + [
+                            {
+                                "result_type": "METRIC",
+                                **m.model_dump(by_alias=False, exclude_none=True),
+                            }
+                            for m in metrics_result.metrics
+                        ]
+                except Exception:
+                    logger.exception("Failed to parse MetricsSearchResult response")
 
         return {"results": results}
 

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -584,16 +584,28 @@ class SearchTableAndViews(Tools):
                   server-side ``dremio.search_topN`` limit.  Cannot exceed that limit.
 
         Returns:
-            A dict with a "results" key containing a list of objects that describe the found
-            tables, views, and (when semantic layer is enabled) metrics.  Each TABLE/VIEW
-            object has "name", "type", "tags", "description", "schema", and optionally
-            "relationships" keys.  Metric objects carry a "result_type" key set to "METRIC".
+            A dict with a "results" key containing
+            1. "table_and_views" key - that has a list of objects that describe the found
+            tables, views, and
+            Each TABLE/VIEW object has "name", "type", "tags", "description", "schema", and optionally
+            "relationships" keys - that tell how this table is related to others.
             The schema is included so you can avoid a separate GetSchemaOfTable call.
+            2. (when semantic layer is enabled) "metrics" key with list of approved metrics
+            along with their definitions
+            3. "note" key with truncation notice if topN was more than server limit.
+
+        You *must* trust relationships and metrics if available and give it more
+        weight when figuring out which tables/views/objectives you are looking for.
         """
-        cfg = settings.instance().dremio
-        server_limit: int = cfg.get("search_topN")
-        max_results = min(topN, server_limit) if topN is not None else server_limit
-        enable_semantic = bool(cfg.get("enable_semantic_layer"))
+        max_results = settings.instance().dremio.get("search_topN")
+        truncated = False
+        if topN is not None:
+            if topN < max_results:
+                max_results = topN
+            else:
+                truncated = True
+
+        enable_semantic = ai_tools.is_semantic_layer_enabled()
 
         search_tasks = [
             search.get_search_results(
@@ -642,15 +654,18 @@ class SearchTableAndViews(Tools):
                         row["relationships"] = None
                 results.append(row)
 
+        ret = {"results": {"tables_and_views": results}}
+        if truncated:
+            ret["results"][
+                "NOTE"
+            ] = f"Search results truncated and capped to {max_results}"
+
         if metric_response and not metric_response.is_empty:
-            results.append(
-                {
-                    "result_type": "METRICS",
-                    **metric_response.model_dump(by_alias=True, exclude_none=True),
-                }
+            ret["results"]["metrics"] = metric_response.model_dump(
+                by_alias=True, exclude_none=True
             )
 
-        return {"results": results}
+        return ret
 
 
 class SearchMetrics(Tools):
@@ -672,7 +687,7 @@ class SearchMetrics(Tools):
         Returns:
             A dict with the metric search results from the Dremio semantic layer.
         """
-        if not settings.instance().dremio.get("enable_semantic_layer"):
+        if not ai_tools.is_semantic_layer_enabled():
             return {
                 "error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."
             }
@@ -705,7 +720,7 @@ class GetTableRelationships(Tools):
         Returns:
             A dict describing the relationships of the specified table or view.
         """
-        if not settings.instance().dremio.get("enable_semantic_layer"):
+        if not ai_tools.is_semantic_layer_enabled():
             return {
                 "error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."
             }

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -557,9 +557,19 @@ class SearchTableAndViews(Tools):
 
     async def get_relationships(
         self, path: List[str]
-    ) -> Tuple[List[str], Optional[List[ai_tools.TableRelationship]]]:
+    ) -> Tuple[List[str], Optional[ai_tools.TableRelationshipsResponse]]:
         result = await ai_tools.get_relationships(path)
-        return path, result
+        if result and not result.is_empty:
+            return path, result
+        return None, None
+
+    async def get_relationships_for_paths(
+        self, paths: List[List[str]]
+    ) -> List[Tuple[List[str], Optional[ai_tools.TableRelationshipsResponse]]]:
+        results = await run_in_parallel(
+            [self.get_relationships(path) for path in paths]
+        )
+        return [(p, r) for p, r in results if r is not None]
 
     @secured
     @with_metrics
@@ -581,13 +591,13 @@ class SearchTableAndViews(Tools):
             The schema is included so you can avoid a separate GetSchemaOfTable call.
         """
         cfg = settings.instance().dremio
-        server_limit: int = cfg.get("search_topN") or 10
+        server_limit: int = cfg.get("search_topN")
         max_results = min(topN, server_limit) if topN is not None else server_limit
         enable_semantic = bool(cfg.get("enable_semantic_layer"))
 
         search_tasks = [
             search.get_search_results(
-                search.Search(query=query, filter=category, max_results=max_results),
+                search.Search(query=query, filter=category, maxResults=max_results),
                 use_df=True,
             )
             for category in (search.Category.TABLE, search.Category.VIEW)
@@ -597,7 +607,9 @@ class SearchTableAndViews(Tools):
 
         res = await run_in_parallel(search_tasks)
         # concat only non-empty DataFrames; both searches may return nothing
-        non_empty = [df for df in res[:2] if isinstance(df, pd.DataFrame) and not df.empty]
+        non_empty = [
+            df for df in res[:2] if isinstance(df, pd.DataFrame) and not df.empty
+        ]
         table_and_views = pd.concat(non_empty) if non_empty else pd.DataFrame()
 
         rel_map: Dict[tuple, list] = {}
@@ -606,28 +618,37 @@ class SearchTableAndViews(Tools):
             metric_response = res[2]
             # path column holds lists (unhashable) — deduplicate via tuples
             paths = (
-                [list(p) for p in {tuple(p) for p in table_and_views["path"].dropna()}]
+                table_and_views["path"].dropna().tolist()
                 if "path" in table_and_views.columns
                 else []
             )
-            rel = await run_in_parallel(
-                [self.get_relationships(p) for p in paths]
+            relationship_responses: List[ai_tools.TableRelationshipsResponse] = (
+                await self.get_relationships_for_paths(paths)
             )
-            for path, relationships in rel:
-                rel_map[tuple(path)] = relationships or []
+            rel_map = {
+                tuple(path): relationship_response
+                for path, relationship_response in relationship_responses
+                if relationship_response and not relationship_response.is_empty
+            }
 
         results = []
         if not table_and_views.empty and "name" in table_and_views.columns:
             for row in table_and_views.to_dict(orient="records"):
-                entry = {k: row.get(k) for k in ("name", "type", "tags", "description", "schema")}
+                path = tuple(row.get("path") or [])
                 if enable_semantic:
-                    if rels := rel_map.get(tuple(row.get("path") or [])):
-                        entry["relationships"] = [r.model_dump(by_alias=False) for r in rels]
-                results.append(entry)
+                    if (rels := rel_map.get(path)) and not rels.is_empty:
+                        row["relationships"] = rels.model_dump(exclude_none=True)
+                    else:
+                        row["relationships"] = None
+                results.append(row)
 
-        if metric_response:
-            for metric in metric_response:
-                results.append({"result_type": "METRIC", **metric.model_dump(by_alias=False)})
+        if metric_response and not metric_response.is_empty:
+            results.append(
+                {
+                    "result_type": "METRICS",
+                    **metric_response.model_dump(by_alias=True, exclude_none=True),
+                }
+            )
 
         return {"results": results}
 

--- a/src/dremioai/tools/tools.py
+++ b/src/dremioai/tools/tools.py
@@ -26,6 +26,7 @@ from typing import (
     get_args,
     get_type_hints,
     Callable,
+    Tuple,
     TypeVar,
     ParamSpec,
     Awaitable,
@@ -143,8 +144,7 @@ def _df_to_json_records(df: pd.DataFrame) -> List[Dict[str, Any]]:
     df = df.where(pd.notnull(df), None)
     records = df.to_dict(orient="records")
     return [
-        {key: _json_safe_value(value) for key, value in row.items()}
-        for row in records
+        {key: _json_safe_value(value) for key, value in row.items()} for row in records
     ]
 
 
@@ -457,9 +457,9 @@ class GetUsefulSystemTableNames(Tools):
                 "Be sure to filter out SYSTEM_TABLE for looking at user tables. "
                 "You must encapsulate TABLES in double quotes."
             ),
-            'sys.project.jobs_recent': "Recent job execution history including status, duration, user, and error details.",
-            'sys.project.engines': "Engine configuration and status for the project.",
-            'sys.organization.users': "Organization user information.",
+            "sys.project.jobs_recent": "Recent job execution history including status, duration, user, and error details.",
+            "sys.project.engines": "Engine configuration and status for the project.",
+            "sys.organization.users": "Organization user information.",
             'INFORMATION_SCHEMA."COLUMNS"': "Column-level metadata for all tables and views.",
             'INFORMATION_SCHEMA."VIEWS"': "View definitions and metadata.",
         }
@@ -485,11 +485,15 @@ class GetSchemaOfTable(Tools):
         """
         if isinstance(table_name, list):
             if not table_name:
-                return {"error": "table_name must not be empty. Provide a list of path components, e.g. ['source', 'schema', 'table']."}
+                return {
+                    "error": "table_name must not be empty. Provide a list of path components, e.g. ['source', 'schema', 'table']."
+                }
             paths = table_name
         else:
             if not table_name or not table_name.strip():
-                return {"error": "table_name must not be empty. Provide a dot-separated name, e.g. '\"source\".\"schema\".\"table\"'."}
+                return {
+                    "error": 'table_name must not be empty. Provide a dot-separated name, e.g. \'"source"."schema"."table"\'.'
+                }
             paths = list(reader(StringIO(table_name), delimiter="."))
         result = await get_schema(paths[0], include_tags=True)
         if result and "sql" in result:
@@ -536,17 +540,26 @@ class SearchTableAndViews(Tools):
         if not settings.instance().dremio.get("enable_semantic_layer"):
             return base
         descriptions = await ai_tools.get_semantic_layer_tool_descriptions()
-        parts = [base, "\nWhen semantic layer is enabled, this tool additionally enriches results:"]
+        parts = [
+            base,
+            "\nWhen semantic layer is enabled, this tool additionally enriches results:",
+        ]
         if sm_desc := descriptions.get("searchMetrics"):
             parts.append(f"- **searchMetrics**: {sm_desc}")
         if rel_desc := descriptions.get("getTableRelationships"):
             parts.append(f"- **getTableRelationships**: {rel_desc}")
         parts.append(
-            "\nMetric results are included with \"result_type\": \"METRIC\"."
-            " TABLE/VIEW results include a \"relationships\" key when relationship data is available."
+            '\nMetric results are included with "result_type": "METRIC".'
+            ' TABLE/VIEW results include a "relationships" key when relationship data is available.'
             " The search returns at most topN results (default set by dremio.search_topN)."
         )
         return "\n".join(parts)
+
+    async def get_relationships(
+        self, path: List[str]
+    ) -> Tuple[List[str], Optional[List[ai_tools.TableRelationship]]]:
+        result = await ai_tools.get_relationships(path)
+        return path, result
 
     @secured
     @with_metrics
@@ -579,70 +592,42 @@ class SearchTableAndViews(Tools):
             )
             for category in (search.Category.TABLE, search.Category.VIEW)
         ]
-
         if enable_semantic:
-            all_results = await run_in_parallel(
-                search_tasks + [ai_tools.invoke_tool("searchMetrics", {"query": query})]
+            search_tasks.append(ai_tools.get_metrics(query))
+
+        res = await run_in_parallel(search_tasks)
+        # concat only non-empty DataFrames; both searches may return nothing
+        non_empty = [df for df in res[:2] if isinstance(df, pd.DataFrame) and not df.empty]
+        table_and_views = pd.concat(non_empty) if non_empty else pd.DataFrame()
+
+        rel_map: Dict[tuple, list] = {}
+        metric_response: Optional[List[ai_tools.Metric]] = None
+        if enable_semantic:
+            metric_response = res[2]
+            # path column holds lists (unhashable) — deduplicate via tuples
+            paths = (
+                [list(p) for p in {tuple(p) for p in table_and_views["path"].dropna()}]
+                if "path" in table_and_views.columns
+                else []
             )
-            table_df, view_df = all_results[0], all_results[1]
-            metric_response = all_results[2]
-        else:
-            table_df, view_df = await run_in_parallel(search_tasks)
-            metric_response = None
-
-        frames = [df for df in (table_df, view_df) if not df.empty]
-        records: List[Dict[str, Any]] = (
-            _df_to_json_records(pd.concat(frames)) if frames else []
-        )
-
-        if enable_semantic and records:
-            rel_responses = await run_in_parallel(
-                [
-                    ai_tools.invoke_tool("getTableRelationShips", {"path": r["path"]})
-                    for r in records
-                    if r.get("path")
-                ]
+            rel = await run_in_parallel(
+                [self.get_relationships(p) for p in paths]
             )
-            rel_iter = iter(rel_responses)
-            for r in records:
-                if r.get("path"):
-                    resp = next(rel_iter)
-                    if resp and not resp.error and resp.result:
-                        try:
-                            rels = [
-                                ai_tools.TableRelationship.model_validate(item)
-                                for item in resp.result
-                            ]
-                            r["relationships"] = [
-                                rel.model_dump(by_alias=False, exclude_none=True)
-                                for rel in rels
-                            ]
-                        except Exception:
-                            logger.exception("Failed to parse TableRelationship response")
-                            r["relationships"] = resp.result  # fallback to raw
+            for path, relationships in rel:
+                rel_map[tuple(path)] = relationships or []
 
-        results: List[Dict[str, Any]] = records
+        results = []
+        if not table_and_views.empty and "name" in table_and_views.columns:
+            for row in table_and_views.to_dict(orient="records"):
+                entry = {k: row.get(k) for k in ("name", "type", "tags", "description", "schema")}
+                if enable_semantic:
+                    if rels := rel_map.get(tuple(row.get("path") or [])):
+                        entry["relationships"] = [r.model_dump(by_alias=False) for r in rels]
+                results.append(entry)
 
-        if enable_semantic and metric_response and not metric_response.error:
-            raw = metric_response.result
-            if isinstance(raw, dict):
-                try:
-                    metrics_result = ai_tools.MetricsSearchResult.model_validate(raw)
-                    if metrics_result.error_message:
-                        logger.warning(
-                            "searchMetrics returned an error",
-                            error=metrics_result.error_message,
-                        )
-                    else:
-                        results = results + [
-                            {
-                                "result_type": "METRIC",
-                                **m.model_dump(by_alias=False, exclude_none=True),
-                            }
-                            for m in metrics_result.metrics
-                        ]
-                except Exception:
-                    logger.exception("Failed to parse MetricsSearchResult response")
+        if metric_response:
+            for metric in metric_response:
+                results.append({"result_type": "METRIC", **metric.model_dump(by_alias=False)})
 
         return {"results": results}
 
@@ -650,9 +635,7 @@ class SearchTableAndViews(Tools):
 class SearchMetrics(Tools):
     """Search for metrics in the Dremio semantic layer using a natural-language query."""
 
-    For: ClassVar[
-        Annotated[ToolType, ToolType.FOR_DATA_PATTERNS | ToolType.EXPERIMENTAL]
-    ]
+    For: ClassVar[Annotated[ToolType, ToolType.DYNAMIC_REMOTE_TOOLS]]
 
     @secured
     @with_metrics
@@ -669,19 +652,23 @@ class SearchMetrics(Tools):
             A dict with the metric search results from the Dremio semantic layer.
         """
         if not settings.instance().dremio.get("enable_semantic_layer"):
-            return {"error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."}
+            return {
+                "error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."
+            }
         result = await ai_tools.invoke_tool("searchMetrics", {"query": query})
         if result.error:
             return {"error": result.error}
-        return result.result if isinstance(result.result, dict) else {"results": result.result}
+        return (
+            result.result
+            if isinstance(result.result, dict)
+            else {"results": result.result}
+        )
 
 
 class GetTableRelationships(Tools):
     """Retrieve relationship metadata for a table or view from the Dremio semantic layer."""
 
-    For: ClassVar[
-        Annotated[ToolType, ToolType.FOR_DATA_PATTERNS | ToolType.EXPERIMENTAL]
-    ]
+    For: ClassVar[Annotated[ToolType, ToolType.DYNAMIC_REMOTE_TOOLS]]
 
     @secured
     @with_metrics
@@ -698,11 +685,17 @@ class GetTableRelationships(Tools):
             A dict describing the relationships of the specified table or view.
         """
         if not settings.instance().dremio.get("enable_semantic_layer"):
-            return {"error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."}
+            return {
+                "error": "Semantic layer is not enabled (dremio.enable_semantic_layer)."
+            }
         result = await ai_tools.invoke_tool("getTableRelationShips", {"path": path})
         if result.error:
             return {"error": result.error}
-        return result.result if isinstance(result.result, dict) else {"result": result.result}
+        return (
+            result.result
+            if isinstance(result.result, dict)
+            else {"result": result.result}
+        )
 
 
 class DiscoverDynamicTools(Tools):

--- a/tests/api/dremio/test_ai_tools.py
+++ b/tests/api/dremio/test_ai_tools.py
@@ -194,10 +194,12 @@ async def test_invoke_tool_url_encodes_name(mock_settings_instance):
         # The encoded name "my%2Ftool" should appear in the URL
         mock.add_mock_response(
             r"/v1/projects/[^/]+/ai/tools/my%2Ftool:invoke$",
-            {"result": "ok", "error": None},
+            {"result": {"status": "ok"}},
         )
         result = await invoke_tool("my/tool", {})
-    assert result.result == "ok"
+    # The key assertion is that the URL was encoded correctly (call succeeded).
+    assert bool(result)
+    assert result.result["status"] == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/api/dremio/test_catalog.py
+++ b/tests/api/dremio/test_catalog.py
@@ -116,7 +116,7 @@ async def test_search_table_and_views_drops_broken_entries_and_returns_healthy_o
         result = await tools_mod.SearchTableAndViews().invoke("NYC bike trips")
 
     assert set(result.keys()) == {"results"}
-    names = {row["name"] for row in result["results"]}
+    names = {row["name"] for row in result["results"]["tables_and_views"]}
     assert "ok.tbl" in names
 
 

--- a/tests/api/dremio/test_catalog.py
+++ b/tests/api/dremio/test_catalog.py
@@ -91,7 +91,9 @@ async def test_populate_schemas_marks_not_found_on_failure():
 
 
 @pytest.mark.asyncio
-async def test_search_table_and_views_drops_broken_entries_and_returns_healthy_ones():
+async def test_search_table_and_views_drops_broken_entries_and_returns_healthy_ones(
+    mock_settings_instance,
+):
     """DX-118395: one broken catalog entry must not fail the whole tool call.
 
     The tool silently drops entries whose schema could not be fetched and

--- a/tests/api/dremio/test_catalog.py
+++ b/tests/api/dremio/test_catalog.py
@@ -86,8 +86,8 @@ async def test_populate_schemas_marks_not_found_on_failure():
         await ok.populate_schemas()
         await bad.populate_schemas()
 
-    assert ok.schema == {"col": "VARCHAR"}
-    assert bad.schema is None
+    assert ok.dremio_schema == {"col": "VARCHAR"}
+    assert bad.dremio_schema is None
 
 
 @pytest.mark.asyncio

--- a/tests/config/golden_flag_keys.yaml
+++ b/tests/config/golden_flag_keys.yaml
@@ -8,11 +8,13 @@ flag_keys:
 - dremio.auth_issuer_uri_override
 - dremio.enable_remote_tools
 - dremio.enable_search
+- dremio.enable_semantic_layer
 - dremio.extract_org_id_from_jwt
 - dremio.jwks_cache_lifespan
 - dremio.jwks_token_expiry_buffer_secs
 - dremio.jwks_uri
 - dremio.metrics.enabled
 - dremio.metrics.port
+- dremio.search_topN
 - dremio.wlm.engine_name
 - log_level

--- a/tests/servers/test_remote_tools.py
+++ b/tests/servers/test_remote_tools.py
@@ -23,6 +23,7 @@ from dremioai.api.dremio.ai_tools import AiTool, InvokeToolResponse, ListToolsRe
 from dremioai.config import settings
 from dremioai.config.tools import ToolType
 from dremioai.servers.mcp import FastMCPServerWithAuthToken
+from mcp.server.fastmcp.exceptions import ToolError
 
 
 def _make_server() -> FastMCPServerWithAuthToken:
@@ -161,16 +162,14 @@ async def test_static_tool_wins_name_collision():
 
 @pytest.mark.asyncio
 async def test_call_unknown_tool_returns_error():
-    """Unknown remote tool → invoke_tool returns error dict."""
+    """Unknown remote tool → invoke_tool error propagates as ToolError (isError=True)."""
     server = _make_server()
 
     invoke_response = InvokeToolResponse(error="tool 'nonexistent_tool' not found")
 
     with patch.object(server, "_invoke_remote_tool", new=AsyncMock(return_value=invoke_response)):
-        result = await server.call_tool("nonexistent_tool", {})
-
-    assert isinstance(result, dict)
-    assert "error" in result
+        with pytest.raises(ToolError, match="nonexistent_tool"):
+            await server.call_tool("nonexistent_tool", {})
 
 
 @pytest.mark.asyncio
@@ -188,12 +187,10 @@ async def test_remote_tool_api_error_handled():
 
 
 @pytest.mark.asyncio
-async def test_remote_tools_disabled_call_returns_error_dict():
-    """call_tool for non-static tool when enable_remote_tools=False returns an error dict."""
+async def test_remote_tools_disabled_call_raises_tool_error():
+    """call_tool for non-static tool when remote tools disabled raises ToolError (isError=True)."""
     settings.set_base_settings(_make_settings(enable_remote_tools=False))
     server = _make_server()
 
-    result = await server.call_tool("any_remote_tool", {})
-
-    assert isinstance(result, dict)
-    assert "error" in result
+    with pytest.raises(ToolError):
+        await server.call_tool("any_remote_tool", {})

--- a/tests/servers/test_remote_tools.py
+++ b/tests/servers/test_remote_tools.py
@@ -89,13 +89,14 @@ async def test_call_remote_tool_directly():
     """call_tool() routes to _invoke_remote_tool for remote tools; returns dict result."""
     server = _make_server()
 
-    invoke_response = InvokeToolResponse(result="hello from remote")
+    from dremioai.api.dremio.ai_tools import InvokeToolResponseResult
+    invoke_response = InvokeToolResponse(result=InvokeToolResponseResult.model_validate({"message": "hello from remote"}))
 
     with patch.object(server, "_invoke_remote_tool", new=AsyncMock(return_value=invoke_response)):
         result = await server.call_tool("my_remote", {})
 
     assert isinstance(result, dict)
-    assert result.get("result") == "hello from remote"
+    assert result.get("result", {}).get("message") == "hello from remote"
 
 
 @pytest.mark.asyncio

--- a/tests/servers/test_remote_tools.py
+++ b/tests/servers/test_remote_tools.py
@@ -1,0 +1,198 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""Tests for FastMCPServerWithAuthToken remote tool listing and invocation."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from dremioai.api.dremio.ai_tools import AiTool, InvokeToolResponse, ListToolsResponse
+from dremioai.config import settings
+from dremioai.config.tools import ToolType
+from dremioai.servers.mcp import FastMCPServerWithAuthToken
+
+
+def _make_server() -> FastMCPServerWithAuthToken:
+    return FastMCPServerWithAuthToken("TestServer", log_level="DEBUG", debug=True)
+
+
+def _make_settings(enable_remote_tools: bool = True):
+    return settings.Settings.model_validate(
+        {
+            "dremio": {
+                "uri": "https://dremio.example.com",
+                "pat": "test-pat",
+                "enable_remote_tools": enable_remote_tools,
+            },
+            "tools": {"server_mode": ToolType.FOR_SELF.name},
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _base_settings(reset_settings_state):
+    settings.set_base_settings(_make_settings(enable_remote_tools=True))
+    yield
+    settings.reset_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_remote_tools():
+    """Merged static + remote returned when enable_remote_tools=True."""
+    server = _make_server()
+
+    async def my_static(x: str) -> str:
+        """A static tool."""
+        return x
+
+    server.add_tool(my_static, name="my_static", description="static")
+
+    remote = [AiTool(name="remote_tool_1", description="A remote tool", inputSchema={"type": "object"})]
+    list_response = ListToolsResponse(tools=remote)
+
+    with patch.object(server, "_list_remote_tools", new=AsyncMock(return_value=list_response)):
+        result = await server.list_tools()
+
+    names = [t.name for t in result]
+    assert "my_static" in names
+    assert "remote_tool_1" in names
+
+
+@pytest.mark.asyncio
+async def test_list_tools_excludes_remote_when_disabled():
+    """enable_remote_tools=False → static tools only; backend not called."""
+    settings.set_base_settings(_make_settings(enable_remote_tools=False))
+    server = _make_server()
+
+    with patch.object(server, "_list_remote_tools", new=AsyncMock()) as mock_list:
+        result = await server.list_tools()
+        mock_list.assert_not_called()
+
+    assert all(t.name != "remote_tool_1" for t in result)
+
+
+@pytest.mark.asyncio
+async def test_call_remote_tool_directly():
+    """call_tool() routes to _invoke_remote_tool for remote tools; returns dict result."""
+    server = _make_server()
+
+    invoke_response = InvokeToolResponse(result="hello from remote")
+
+    with patch.object(server, "_invoke_remote_tool", new=AsyncMock(return_value=invoke_response)):
+        result = await server.call_tool("my_remote", {})
+
+    assert isinstance(result, dict)
+    assert result.get("result") == "hello from remote"
+
+
+@pytest.mark.asyncio
+async def test_call_static_tool_unchanged():
+    """Static tools route through super().call_tool(); _invoke_remote_tool is not called."""
+    server = _make_server()
+
+    async def my_static_tool(x: str) -> str:
+        """A static tool for testing."""
+        return f"static:{x}"
+
+    server.add_tool(my_static_tool, name="my_static_tool", description="test static tool")
+
+    with patch.object(server, "_invoke_remote_tool", new=AsyncMock()) as mock_invoke:
+        result = await server.call_tool("my_static_tool", {"x": "hello"})
+        mock_invoke.assert_not_called()
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_different_project_ids_different_tools():
+    """Each list_tools() call hits backend independently — no shared cache."""
+    server = _make_server()
+
+    call_count = 0
+
+    async def fake_list_remote(self_=None):
+        nonlocal call_count
+        call_count += 1
+        return ListToolsResponse(tools=[])
+
+    with patch.object(server, "_list_remote_tools", side_effect=fake_list_remote):
+        await server.list_tools()
+        await server.list_tools()
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_static_tool_wins_name_collision():
+    """If a remote tool has the same name as a static tool, static wins and warning is logged."""
+    server = _make_server()
+
+    async def colliding_tool() -> str:
+        """A static tool that collides with a remote tool name."""
+        return "static"
+
+    server.add_tool(colliding_tool, name="colliding_tool", description="static")
+
+    remote = [AiTool(name="colliding_tool", description="remote", inputSchema={"type": "object"})]
+    list_response = ListToolsResponse(tools=remote)
+
+    with patch.object(server, "_list_remote_tools", new=AsyncMock(return_value=list_response)):
+        with patch.object(server._logger, "warning") as mock_warn:
+            result = await server.list_tools()
+            assert mock_warn.called
+
+    collision_tools = [t for t in result if t.name == "colliding_tool"]
+    assert len(collision_tools) == 1
+
+
+@pytest.mark.asyncio
+async def test_call_unknown_tool_returns_error():
+    """Unknown remote tool → invoke_tool returns error dict."""
+    server = _make_server()
+
+    invoke_response = InvokeToolResponse(error="tool 'nonexistent_tool' not found")
+
+    with patch.object(server, "_invoke_remote_tool", new=AsyncMock(return_value=invoke_response)):
+        result = await server.call_tool("nonexistent_tool", {})
+
+    assert isinstance(result, dict)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_remote_tool_api_error_handled():
+    """If _list_remote_tools() response has .error, degrade to static tools only."""
+    server = _make_server()
+
+    error_response = ListToolsResponse(error="service unavailable")
+
+    with patch.object(server, "_list_remote_tools", new=AsyncMock(return_value=error_response)):
+        result = await server.list_tools()
+
+    remote_names = [t.name for t in result if t.name == "remote_tool_1"]
+    assert len(remote_names) == 0
+
+
+@pytest.mark.asyncio
+async def test_remote_tools_disabled_call_returns_error_dict():
+    """call_tool for non-static tool when enable_remote_tools=False returns an error dict."""
+    settings.set_base_settings(_make_settings(enable_remote_tools=False))
+    server = _make_server()
+
+    result = await server.call_tool("any_remote_tool", {})
+
+    assert isinstance(result, dict)
+    assert "error" in result

--- a/tests/servers/test_remote_tools.py
+++ b/tests/servers/test_remote_tools.py
@@ -37,7 +37,7 @@ def _make_settings(enable_remote_tools: bool = True):
                 "pat": "test-pat",
                 "enable_remote_tools": enable_remote_tools,
             },
-            "tools": {"server_mode": ToolType.FOR_SELF.name},
+            "tools": {"server_mode": ToolType.DYNAMIC_REMOTE_TOOLS.name},
         }
     )
 

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -10,6 +10,7 @@ import contextlib
 import functools
 import json
 import random
+import sys
 import threading
 import time
 from datetime import datetime, timezone
@@ -26,7 +27,7 @@ from mcp.shared.auth import OAuthMetadata
 import requests
 import uvicorn
 import yaml
-from rich import print as pp
+from rich import print as pp, print_json as pj
 from rich.markdown import Markdown
 from rich.table import Table
 from typer import Typer, Option
@@ -176,7 +177,7 @@ def _resolve_token(
 
     cache = _read_auth_cache(url)
     if cache.token:
-        pp(f"[dim]Using cached token for {url}[/dim]")
+        pp(f"[dim]Using cached token for {url}[/dim]", file=sys.stderr)
         return cache.token, cache
 
     # No cached token — try the OAuth flow.
@@ -721,7 +722,7 @@ async def call_tool(
             pp("[red]Error[/red]")
             pp(result.content)
             return
-        pp(result.structuredContent["result"])
+        pj(data=result.structuredContent["result"])
 
 
 def _assert(condition: bool, msg: str):

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -1289,6 +1289,10 @@ app.add_typer(cli)
 app.add_typer(auth)
 
 
-if __name__ == "__main__":
+def main():
     log.configure(enable_json_logging=False, to_file=False)
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -170,6 +170,7 @@ def _resolve_token(
     Returns ``(token, AuthCache)``.  The cache is empty when the caller supplied
     an explicit token.
     """
+    url = _normalize_url(url)
     if explicit_token is not None:
         return explicit_token, AuthCache()
 
@@ -211,6 +212,7 @@ def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
     On success writes the new token to cache and returns it.
     Returns ``None`` if the cache lacks a refresh token or the refresh fails.
     """
+    url = _normalize_url(url)
     if not (cache.refresh_token and cache.client_id):
         return None
     try:
@@ -230,7 +232,7 @@ def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
     return None
 
 
-def with_auth(fn: "Callable[..., Awaitable[Any]]") -> "Callable[..., Awaitable[Any]]":
+def with_auth(fn: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
     """Decorator: resolve bearer token (explicit → cache → OAuth) and retry once on 401.
 
     The wrapped function's ``token`` kwarg is replaced with the resolved token
@@ -290,6 +292,17 @@ auth = Typer(
 )
 
 
+def _normalize_url(url: str) -> str:
+    """Canonicalize *url* so it is always usable as an unambiguous cache key.
+
+    * Prepends ``https://`` when no scheme is present.
+    * Strips a trailing ``/`` to avoid ``/mcp`` vs ``/mcp/`` mismatches.
+    """
+    if url and not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    return url.rstrip("/")
+
+
 def get_oauth_config(url: str) -> OAuthMetadata:
     u = urlparse(url)
     u = u._replace(path="/.well-known/oauth-authorization-server")
@@ -345,6 +358,7 @@ def check_auth(
         str, Option(help="Path for OAuth redirect (e.g. /Callback)")
     ] = "/",
 ) -> OAuth2Redirect:
+    url = _normalize_url(url or "http://127.0.0.1:8000/mcp")
     md = get_oauth_config(url)
     oauth = get_oauth2_tokens(
         client_id,
@@ -353,7 +367,7 @@ def check_auth(
         redirect_port,
         redirect_path,
     )
-    if url and oauth.access_token:
+    if oauth.access_token:
         cache_update(
             url=url,
             token=oauth.access_token,
@@ -546,6 +560,7 @@ def cache_update(
                           --refresh-token rrt_... \\
                           --client-id my-client-id
     """
+    url = _normalize_url(url)
     _write_auth_cache(
         url,
         AuthCache(token=token, refresh_token=refresh_token, client_id=client_id),
@@ -560,6 +575,8 @@ def cache_show(
     ] = None,
 ):
     """Display the current auth cache contents (tokens are redacted)."""
+    if url:
+        url = _normalize_url(url)
     store = _read_auth_store()
     if not store.root:
         pp("[dim]Auth cache is empty.[/dim]")
@@ -632,6 +649,12 @@ async def list_tools(
     client_id: Annotated[
         Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
     ] = None,
+    redirect_port: Annotated[
+        int, Option("--redirect-port", help="Local port for OAuth redirect listener")
+    ] = 8976,
+    redirect_path: Annotated[
+        str, Option("--redirect-path", help="Path for OAuth redirect (e.g. /Callback)")
+    ] = "/",
 ):
     async with mcp_client_session(url, token) as session:
         result = await session.list_tools()
@@ -659,6 +682,12 @@ async def call_tool(
     client_id: Annotated[
         Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
     ] = None,
+    redirect_port: Annotated[
+        int, Option("--redirect-port", help="Local port for OAuth redirect listener")
+    ] = 8976,
+    redirect_path: Annotated[
+        str, Option("--redirect-path", help="Path for OAuth redirect (e.g. /Callback)")
+    ] = "/",
     args: Annotated[
         Optional[str], Option(help="The arguments to pass to the tool as a JSON")
     ] = None,

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -200,7 +200,9 @@ def _resolve_token(
         pp("[red]OAuth flow did not return a token.[/red]")
         raise SystemExit(1)
 
-    new_cache = AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id)
+    new_cache = AuthCache(
+        token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id
+    )
     _write_auth_cache(url, new_cache)
     pp(f"[green]Authenticated.[/green]  Token cached for {url}")
     return oauth.access_token, new_cache
@@ -221,11 +223,14 @@ def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
             str(oauth_meta.token_endpoint), cache.client_id, cache.refresh_token
         )
         if new_token:
-            _write_auth_cache(url, AuthCache(
-                token=new_token,
-                refresh_token=new_refresh or cache.refresh_token,
-                client_id=cache.client_id,
-            ))
+            _write_auth_cache(
+                url,
+                AuthCache(
+                    token=new_token,
+                    refresh_token=new_refresh or cache.refresh_token,
+                    client_id=cache.client_id,
+                ),
+            )
             return new_token
     except Exception as exc:
         pp(f"[yellow]Token refresh failed: {exc}[/yellow]")
@@ -246,6 +251,7 @@ def with_auth(fn: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]
             async with mcp_client_session(url, token) as session:
                 ...  # token is already resolved here
     """
+
     @functools.wraps(fn)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         url = kwargs.get("url") or "http://127.0.0.1:8000/mcp"
@@ -253,8 +259,11 @@ def with_auth(fn: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]
         redirect_path = kwargs.get("redirect_path", "/")
 
         resolved, cache = _resolve_token(
-            kwargs.get("token"), url, kwargs.get("client_id"),
-            redirect_port, redirect_path,
+            kwargs.get("token"),
+            url,
+            kwargs.get("client_id"),
+            redirect_port,
+            redirect_path,
         )
         try:
             return await fn(*args, **{**kwargs, "token": resolved})
@@ -547,7 +556,8 @@ def cache_update(
         Optional[str], Option("--refresh-token", help="Refresh token (optional)")
     ] = None,
     client_id: Annotated[
-        Optional[str], Option("--client-id", help="OAuth client ID (needed for future refresh)")
+        Optional[str],
+        Option("--client-id", help="OAuth client ID (needed for future refresh)"),
     ] = None,
 ):
     """Write or overwrite the cached credentials for a given MCP server URL.
@@ -573,6 +583,9 @@ def cache_show(
     url: Annotated[
         Optional[str], Option(help="Show only the entry for this URL (omit for all)")
     ] = None,
+    token_only: Annotated[
+        Optional[bool], Option(help="Show only the entry for this URL")
+    ] = False,
 ):
     """Display the current auth cache contents (tokens are redacted)."""
     if url:
@@ -582,9 +595,14 @@ def cache_show(
         pp("[dim]Auth cache is empty.[/dim]")
         return
     entries = {url: store.root[url]} if url and url in store.root else store.root
-    if url and url not in store.root:
+    if url and url not in entries:
         pp(f"[yellow]No cache entry found for {url}[/yellow]")
         return
+
+    if token_only:
+        print(entries[url].token)
+        return
+
     tbl = Table(title="Auth Cache (~/.config/dremioai/.auth.yaml)")
     tbl.add_column("URL")
     tbl.add_column("token")
@@ -608,6 +626,24 @@ cli = Typer(
 )
 
 
+def _unwrap_401(exc: BaseException) -> httpx.HTTPStatusError | None:
+    """Return the first HTTPStatusError with status 401 buried inside *exc*.
+
+    ``streamablehttp_client`` runs streams inside an anyio/asyncio TaskGroup,
+    so transport-level errors arrive wrapped in an ``ExceptionGroup``.  This
+    function recursively unwraps both plain exceptions and ExceptionGroups to
+    find the culprit.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc if exc.response.status_code == 401 else None
+    if isinstance(exc, BaseExceptionGroup):
+        for sub in exc.exceptions:
+            found = _unwrap_401(sub)
+            if found is not None:
+                return found
+    return None
+
+
 @asynccontextmanager
 async def mcp_client_session(
     url: str, token: Optional[str] = None
@@ -624,12 +660,11 @@ async def mcp_client_session(
                 yield session
     except TokenExpiredError:
         raise  # already converted — let it propagate
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 401:
-            raise TokenExpiredError(str(exc)) from exc
-        raise
-    except Exception as exc:
-        # Fallback for non-httpx transports that signal auth failures via message text
+    except BaseException as exc:
+        # streamablehttp_client wraps transport errors in ExceptionGroup; unwrap
+        # to find any 401 HTTPStatusError before falling back to text matching.
+        if found := _unwrap_401(exc):
+            raise TokenExpiredError(str(found)) from found
         msg = str(exc).lower()
         if "401" in msg or "unauthorized" in msg:
             raise TokenExpiredError(str(exc)) from exc
@@ -647,7 +682,8 @@ async def list_tools(
         Optional[str], Option(help="The authorization token to use")
     ] = None,
     client_id: Annotated[
-        Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
+        Optional[str],
+        Option(help="OAuth client ID (used when no --token or cached token)"),
     ] = None,
     redirect_port: Annotated[
         int, Option("--redirect-port", help="Local port for OAuth redirect listener")
@@ -660,7 +696,9 @@ async def list_tools(
         result = await session.list_tools()
         tools = result.tools
 
-    tbl = Table(title=f"Tools — {url}", show_header=True, header_style="bold", show_lines=True)
+    tbl = Table(
+        title=f"Tools — {url}", show_header=True, header_style="bold", show_lines=True
+    )
     tbl.add_column("Tool", style="bold cyan", no_wrap=True)
     tbl.add_column("Description")
     for tool in tools:
@@ -680,7 +718,8 @@ async def call_tool(
         Optional[str], Option(help="The authorization token to use")
     ] = None,
     client_id: Annotated[
-        Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
+        Optional[str],
+        Option(help="OAuth client ID (used when no --token or cached token)"),
     ] = None,
     redirect_port: Annotated[
         int, Option("--redirect-port", help="Local port for OAuth redirect listener")
@@ -849,14 +888,18 @@ async def run_test(
                 ld_expected=ld_expected,
             )
 
-        resolved, cache = _resolve_token(token, url, client_id, redirect_port, redirect_path)
+        resolved, cache = _resolve_token(
+            token, url, client_id, redirect_port, redirect_path
+        )
         try:
             await _do_remote(resolved)
         except TokenExpiredError:
             pp("[yellow]Token expired — refreshing...[/yellow]")
             new_token = _handle_token_expired(url, cache)
             if not new_token:
-                pp("[red]Token refresh failed.[/red]  Re-authenticate with --client-id or supply a new --token.")
+                pp(
+                    "[red]Token refresh failed.[/red]  Re-authenticate with --client-id or supply a new --token."
+                )
                 raise SystemExit(1)
             pp("[green]Token refreshed — retrying...[/green]")
             await _do_remote(new_token)
@@ -1166,16 +1209,25 @@ async def _run_smoketests(
         if check_remote_tools:
             pp("Checking remote tools in tools/list..", end=" ")
             static_tool_names = {
-                "RunSqlQuery", "GetUsefulSystemTableNames", "GetSchemaOfTable",
-                "GetDescriptionOfTableOrSchema", "GetTableOrViewLineage",
-                "SearchTableAndViews", "DiscoverDynamicTools", "CallDynamicTool",
+                "RunSqlQuery",
+                "GetUsefulSystemTableNames",
+                "GetSchemaOfTable",
+                "GetDescriptionOfTableOrSchema",
+                "GetTableOrViewLineage",
+                "SearchTableAndViews",
+                "DiscoverDynamicTools",
+                "CallDynamicTool",
             }
-            remote_tools = [t for t in tools_result.tools if t.name not in static_tool_names]
+            remote_tools = [
+                t for t in tools_result.tools if t.name not in static_tool_names
+            ]
             _assert(
                 len(remote_tools) > 0,
                 f"No remote tools found in tools/list (got {[t.name for t in tools_result.tools]})",
             )
-            pp(f"{len(remote_tools)} remote tool(s) found: {[t.name for t in remote_tools]}")
+            pp(
+                f"{len(remote_tools)} remote tool(s) found: {[t.name for t in remote_tools]}"
+            )
 
             # Call the first remote tool with no arguments to verify routing works
             first_remote = remote_tools[0]

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -1219,7 +1219,8 @@ async def _run_smoketests(
             pp(f"Calling remote tool '{first_remote.name}'..", end=" ")
             result = await session.call_tool(first_remote.name, {})
             _assert(
-                result.structuredContent is not None or not result.isError,
+                not result.isError
+                and "error" not in (result.structuredContent or {}),
                 f"Remote tool call failed: {result.content}",
             )
             pp("[green]OK[/green]")

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -648,8 +648,6 @@ async def mcp_client_session(
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
                 yield session
-    except* TokenExpiredError:
-        raise  # already converted upstream — propagate as-is
     except* httpx.HTTPStatusError as eg:
         for exc in eg.exceptions:
             if exc.response.status_code == 401:

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Annotated, Any, Awaitable, AsyncGenerator, Callable, Dict, Optional
 from urllib.parse import urlparse
 
+import httpx
 import jwt
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
@@ -195,37 +196,45 @@ def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
     return None
 
 
-async def with_auth(
-    url: str,
-    explicit_token: str | None,
-    client_id: str | None,
-    op: "Callable[[str], Awaitable[Any]]",
-    redirect_port: int = 8976,
-    redirect_path: str = "/",
-) -> None:
-    """Resolve a bearer token, run ``await op(token)``, and retry once on 401.
+def with_auth(fn: "Callable[..., Awaitable[Any]]") -> "Callable[..., Awaitable[Any]]":
+    """Decorator: resolve bearer token (explicit → cache → OAuth) and retry once on 401.
 
-    Combines token resolution (explicit → cache → OAuth flow) with automatic
-    refresh-token retry so callers need not repeat the pattern themselves::
+    The wrapped function's ``token`` kwarg is replaced with the resolved token
+    before the call.  The function must accept ``url``, ``token``, and optionally
+    ``client_id``, ``redirect_port``, ``redirect_path``::
 
-        await with_auth(url, token, client_id, lambda tok: _do_stuff(url, tok))
+        @cli.command("list-tools")
+        @async_command
+        @with_auth
+        async def list_tools(url=..., token=None, client_id=None):
+            async with mcp_client_session(url, token) as session:
+                ...  # token is already resolved here
     """
-    resolved_token, cache = _resolve_token(
-        explicit_token, url, client_id, redirect_port, redirect_path
-    )
-    try:
-        await op(resolved_token)
-    except TokenExpiredError:
-        pp("[yellow]Token expired — refreshing...[/yellow]")
-        new_token = _handle_token_expired(url, cache)
-        if not new_token:
-            pp(
-                "[red]Token refresh failed.[/red]  "
-                "Re-authenticate with --client-id or supply a new --token."
-            )
-            raise SystemExit(1)
-        pp("[green]Token refreshed — retrying...[/green]")
-        await op(new_token)
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        url = kwargs.get("url") or "http://127.0.0.1:8000/mcp"
+        redirect_port = kwargs.get("redirect_port", 8976)
+        redirect_path = kwargs.get("redirect_path", "/")
+
+        resolved, cache = _resolve_token(
+            kwargs.get("token"), url, kwargs.get("client_id"),
+            redirect_port, redirect_path,
+        )
+        try:
+            return await fn(*args, **{**kwargs, "token": resolved})
+        except TokenExpiredError:
+            pp("[yellow]Token expired — refreshing...[/yellow]")
+            new_token = _handle_token_expired(url, cache)
+            if not new_token:
+                pp(
+                    "[red]Token refresh failed.[/red]  "
+                    "Re-authenticate with --client-id or supply a new --token."
+                )
+                raise SystemExit(1)
+            pp("[green]Token refreshed — retrying...[/green]")
+            return await fn(*args, **{**kwargs, "token": new_token})
+
+    return wrapper
 
 
 # ---------------------------------------------------------------------------
@@ -484,11 +493,6 @@ cli = Typer(
 )
 
 
-def _is_auth_error(exc: Exception) -> bool:
-    msg = str(exc).lower()
-    return "401" in msg or "unauthorized" in msg or "unauthenticated" in msg
-
-
 @asynccontextmanager
 async def mcp_client_session(
     url: str, token: Optional[str] = None
@@ -505,14 +509,21 @@ async def mcp_client_session(
                 yield session
     except TokenExpiredError:
         raise  # already converted — let it propagate
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise TokenExpiredError(str(exc)) from exc
+        raise
     except Exception as exc:
-        if _is_auth_error(exc):
+        # Fallback for non-httpx transports that signal auth failures via message text
+        msg = str(exc).lower()
+        if "401" in msg or "unauthorized" in msg:
             raise TokenExpiredError(str(exc)) from exc
         raise
 
 
 @cli.command("list-tools")
 @async_command
+@with_auth
 async def list_tools(
     url: Annotated[
         Optional[str], Option(help="The URL of the MCP server")
@@ -524,16 +535,14 @@ async def list_tools(
         Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
     ] = None,
 ):
-    async def _run(tok: str) -> None:
-        async with mcp_client_session(url, tok) as session:
-            for tool in await session.list_tools():
-                pp(tool)
-
-    await with_auth(url, token, client_id, _run)
+    async with mcp_client_session(url, token) as session:
+        for tool in await session.list_tools():
+            pp(tool)
 
 
 @cli.command("call-tool")
 @async_command
+@with_auth
 async def call_tool(
     tool: Annotated[str, Option(help="The tool to call")],
     url: Annotated[
@@ -549,16 +558,13 @@ async def call_tool(
         Optional[str], Option(help="The arguments to pass to the tool as a JSON")
     ] = None,
 ):
-    async def _run(tok: str) -> None:
-        async with mcp_client_session(url, tok) as session:
-            result = await session.call_tool(tool, json.loads(args) if args else None)
-            if result.isError:
-                pp("[red]Error[/red]")
-                pp(result.content)
-                return
-            pp(result.structuredContent["result"])
-
-    await with_auth(url, token, client_id, _run)
+    async with mcp_client_session(url, token) as session:
+        result = await session.call_tool(tool, json.loads(args) if args else None)
+        if result.isError:
+            pp("[red]Error[/red]")
+            pp(result.content)
+            return
+        pp(result.structuredContent["result"])
 
 
 def _assert(condition: bool, msg: str):
@@ -696,7 +702,7 @@ async def run_test(
     ] = "/",
 ):
     if not local:
-        # Remote mode — with_auth handles token resolution and 401 retry.
+        # Remote mode — resolve token then run smoketests, retry once on 401.
         async def _do_remote(tok: str) -> None:
             await _run_smoketests(
                 url,
@@ -709,7 +715,17 @@ async def run_test(
                 ld_expected=ld_expected,
             )
 
-        await with_auth(url, token, client_id, _do_remote, redirect_port, redirect_path)
+        resolved, cache = _resolve_token(token, url, client_id, redirect_port, redirect_path)
+        try:
+            await _do_remote(resolved)
+        except TokenExpiredError:
+            pp("[yellow]Token expired — refreshing...[/yellow]")
+            new_token = _handle_token_expired(url, cache)
+            if not new_token:
+                pp("[red]Token refresh failed.[/red]  Re-authenticate with --client-id or supply a new --token.")
+                raise SystemExit(1)
+            pp("[green]Token refreshed — retrying...[/green]")
+            await _do_remote(new_token)
         return
 
     # Local mode: start a local MCP server and test against it

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Annotated, Optional, AsyncGenerator, Callable, Any, Dict
+from typing import Annotated, Any, Awaitable, AsyncGenerator, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 import jwt
@@ -37,7 +37,7 @@ from dremioai.config import settings
 from dremioai.config.feature_flags import FeatureFlagManager
 from dremioai.config.tools import ToolType
 from dremioai.servers.mcp import FastMCPServerWithAuthToken, init, Transports
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 def async_command(func: Callable) -> Callable:
@@ -57,34 +57,39 @@ def async_command(func: Callable) -> Callable:
 _AUTH_CACHE_PATH = Path.home() / ".config" / "dremioai" / ".auth.yaml"
 
 
-class _TokenExpiredError(Exception):
+class TokenExpiredError(Exception):
     """Raised when a 401 Unauthorized is detected from the MCP server."""
 
 
-def _read_auth_cache() -> dict:
-    """Read ~/.config/dremioai/.auth.yaml; returns {} when absent or malformed."""
+class AuthCache(BaseModel):
+    """Typed representation of ``~/.config/dremioai/.auth.yaml``."""
+
+    token: str | None = None
+    refresh_token: str | None = Field(None, alias="refresh-token")
+    client_id: str | None = Field(None, alias="client-id")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+def _read_auth_cache() -> AuthCache:
+    """Read ``~/.config/dremioai/.auth.yaml``; returns an empty cache when absent or malformed."""
     if not _AUTH_CACHE_PATH.exists():
-        return {}
+        return AuthCache()
     try:
         data = yaml.safe_load(_AUTH_CACHE_PATH.read_text())
-        return data if isinstance(data, dict) else {}
+        if isinstance(data, dict):
+            return AuthCache.model_validate(data)
     except Exception:
-        return {}
+        pass
+    return AuthCache()
 
 
-def _write_auth_cache(
-    token: str,
-    refresh_token: str | None = None,
-    client_id: str | None = None,
-) -> None:
-    """Persist token (and optionally refresh-token / client-id) to the auth cache."""
+def _write_auth_cache(cache: AuthCache) -> None:
+    """Persist *cache* to ``~/.config/dremioai/.auth.yaml``."""
     _AUTH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    data: dict = {"token": token}
-    if refresh_token:
-        data["refresh-token"] = refresh_token
-    if client_id:
-        data["client-id"] = client_id
-    _AUTH_CACHE_PATH.write_text(yaml.safe_dump(data))
+    _AUTH_CACHE_PATH.write_text(
+        yaml.safe_dump(cache.model_dump(by_alias=True, exclude_none=True))
+    )
 
 
 def _do_token_refresh(
@@ -120,24 +125,23 @@ def _resolve_token(
     client_id: str | None,
     redirect_port: int,
     redirect_path: str,
-) -> tuple[str, dict]:
+) -> tuple[str, AuthCache]:
     """Return the bearer token to use, in priority order:
 
     1. *explicit_token* (``--token`` flag) — cache is bypassed entirely.
-    2. ``~/.config/dremioai/.auth.yaml`` ``token:`` key.
+    2. ``~/.config/dremioai/.auth.yaml`` ``token`` field.
     3. Full OAuth PKCE flow (requires *client_id*); writes result to cache.
 
-    Returns ``(token, cache_dict)``.  *cache_dict* is empty when the caller
-    supplied an explicit token.
+    Returns ``(token, AuthCache)``.  The cache is empty when the caller supplied
+    an explicit token.
     """
     if explicit_token is not None:
-        return explicit_token, {}
+        return explicit_token, AuthCache()
 
     cache = _read_auth_cache()
-    cached_token = cache.get("token")
-    if cached_token:
+    if cache.token:
         pp("[dim]Using cached token (~/.config/dremioai/.auth.yaml)[/dim]")
-        return cached_token, cache
+        return cache.token, cache
 
     # No cached token — try the OAuth flow.
     if not client_id:
@@ -160,35 +164,68 @@ def _resolve_token(
         pp("[red]OAuth flow did not return a token.[/red]")
         raise SystemExit(1)
 
-    _write_auth_cache(oauth.access_token, oauth.refresh_token, client_id)
-    pp(
-        "[green]Authenticated.[/green]  "
-        "Token cached at ~/.config/dremioai/.auth.yaml"
-    )
-    return oauth.access_token, _read_auth_cache()
+    new_cache = AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id)
+    _write_auth_cache(new_cache)
+    pp("[green]Authenticated.[/green]  Token cached at ~/.config/dremioai/.auth.yaml")
+    return oauth.access_token, new_cache
 
 
-def _handle_token_expired(url: str, cache: dict) -> str | None:
+def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
     """Attempt a token refresh using the cached refresh token.
 
     On success writes the new token to cache and returns it.
     Returns ``None`` if the cache lacks a refresh token or the refresh fails.
     """
-    refresh_tok = cache.get("refresh-token")
-    client_id = cache.get("client-id")
-    if not (refresh_tok and client_id):
+    if not (cache.refresh_token and cache.client_id):
         return None
     try:
         oauth_meta = get_oauth_config(url)
         new_token, new_refresh = _do_token_refresh(
-            str(oauth_meta.token_endpoint), client_id, refresh_tok
+            str(oauth_meta.token_endpoint), cache.client_id, cache.refresh_token
         )
         if new_token:
-            _write_auth_cache(new_token, new_refresh or refresh_tok, client_id)
+            _write_auth_cache(AuthCache(
+                token=new_token,
+                refresh_token=new_refresh or cache.refresh_token,
+                client_id=cache.client_id,
+            ))
             return new_token
     except Exception as exc:
         pp(f"[yellow]Token refresh failed: {exc}[/yellow]")
     return None
+
+
+async def with_auth(
+    url: str,
+    explicit_token: str | None,
+    client_id: str | None,
+    op: "Callable[[str], Awaitable[Any]]",
+    redirect_port: int = 8976,
+    redirect_path: str = "/",
+) -> None:
+    """Resolve a bearer token, run ``await op(token)``, and retry once on 401.
+
+    Combines token resolution (explicit → cache → OAuth flow) with automatic
+    refresh-token retry so callers need not repeat the pattern themselves::
+
+        await with_auth(url, token, client_id, lambda tok: _do_stuff(url, tok))
+    """
+    resolved_token, cache = _resolve_token(
+        explicit_token, url, client_id, redirect_port, redirect_path
+    )
+    try:
+        await op(resolved_token)
+    except TokenExpiredError:
+        pp("[yellow]Token expired — refreshing...[/yellow]")
+        new_token = _handle_token_expired(url, cache)
+        if not new_token:
+            pp(
+                "[red]Token refresh failed.[/red]  "
+                "Re-authenticate with --client-id or supply a new --token."
+            )
+            raise SystemExit(1)
+        pp("[green]Token refreshed — retrying...[/green]")
+        await op(new_token)
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +310,7 @@ def check_auth(
         redirect_port,
         redirect_path,
     )
-    _write_auth_cache(oauth.access_token, oauth.refresh_token, client_id)
+    _write_auth_cache(AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id))
     pp(oauth.access_token)
     return oauth
 
@@ -466,11 +503,11 @@ async def mcp_client_session(
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
                 yield session
-    except _TokenExpiredError:
+    except TokenExpiredError:
         raise  # already converted — let it propagate
     except Exception as exc:
         if _is_auth_error(exc):
-            raise _TokenExpiredError(str(exc)) from exc
+            raise TokenExpiredError(str(exc)) from exc
         raise
 
 
@@ -487,23 +524,12 @@ async def list_tools(
         Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
     ] = None,
 ):
-    resolved_token, cache = _resolve_token(token, url, client_id, 8976, "/")
-
-    async def _do(tok: str) -> None:
+    async def _run(tok: str) -> None:
         async with mcp_client_session(url, tok) as session:
-            tools = await session.list_tools()
-            for tool in tools:
+            for tool in await session.list_tools():
                 pp(tool)
 
-    try:
-        await _do(resolved_token)
-    except _TokenExpiredError:
-        pp("[yellow]Token expired — refreshing...[/yellow]")
-        new_token = _handle_token_expired(url, cache)
-        if not new_token:
-            pp("[red]Refresh failed. Re-authenticate with --client-id.[/red]")
-            raise SystemExit(1)
-        await _do(new_token)
+    await with_auth(url, token, client_id, _run)
 
 
 @cli.command("call-tool")
@@ -523,9 +549,7 @@ async def call_tool(
         Optional[str], Option(help="The arguments to pass to the tool as a JSON")
     ] = None,
 ):
-    resolved_token, cache = _resolve_token(token, url, client_id, 8976, "/")
-
-    async def _do(tok: str) -> None:
+    async def _run(tok: str) -> None:
         async with mcp_client_session(url, tok) as session:
             result = await session.call_tool(tool, json.loads(args) if args else None)
             if result.isError:
@@ -534,15 +558,7 @@ async def call_tool(
                 return
             pp(result.structuredContent["result"])
 
-    try:
-        await _do(resolved_token)
-    except _TokenExpiredError:
-        pp("[yellow]Token expired — refreshing...[/yellow]")
-        new_token = _handle_token_expired(url, cache)
-        if not new_token:
-            pp("[red]Refresh failed. Re-authenticate with --client-id.[/red]")
-            raise SystemExit(1)
-        await _do(new_token)
+    await with_auth(url, token, client_id, _run)
 
 
 def _assert(condition: bool, msg: str):
@@ -680,12 +696,8 @@ async def run_test(
     ] = "/",
 ):
     if not local:
-        # Remote mode — resolve the token, then run smoketests with 401 retry.
-        resolved_token, cache = _resolve_token(
-            token, url, client_id, redirect_port, redirect_path
-        )
-
-        async def _do_remote_tests(tok: str) -> None:
+        # Remote mode — with_auth handles token resolution and 401 retry.
+        async def _do_remote(tok: str) -> None:
             await _run_smoketests(
                 url,
                 tok,
@@ -697,19 +709,7 @@ async def run_test(
                 ld_expected=ld_expected,
             )
 
-        try:
-            await _do_remote_tests(resolved_token)
-        except _TokenExpiredError:
-            pp("[yellow]Token expired — refreshing...[/yellow]")
-            new_token = _handle_token_expired(url, cache)
-            if not new_token:
-                pp(
-                    "[red]Token refresh failed.[/red]  "
-                    "Re-authenticate with --client-id or supply a new --token."
-                )
-                raise SystemExit(1)
-            pp("[green]Token refreshed — retrying...[/green]")
-            await _do_remote_tests(new_token)
+        await with_auth(url, token, client_id, _do_remote, redirect_port, redirect_path)
         return
 
     # Local mode: start a local MCP server and test against it

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -38,7 +38,7 @@ from dremioai.config import settings
 from dremioai.config.feature_flags import FeatureFlagManager
 from dremioai.config.tools import ToolType
 from dremioai.servers.mcp import FastMCPServerWithAuthToken, init, Transports
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
 def async_command(func: Callable) -> Callable:
@@ -63,7 +63,7 @@ class TokenExpiredError(Exception):
 
 
 class AuthCache(BaseModel):
-    """Typed representation of ``~/.config/dremioai/.auth.yaml``."""
+    """Per-URI token entry stored in ``~/.config/dremioai/.auth.yaml``."""
 
     token: str | None = None
     refresh_token: str | None = Field(None, alias="refresh-token")
@@ -72,25 +72,58 @@ class AuthCache(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-def _read_auth_cache() -> AuthCache:
-    """Read ``~/.config/dremioai/.auth.yaml``; returns an empty cache when absent or malformed."""
+class AuthCacheStore(RootModel[dict[str, AuthCache]]):
+    """Auth cache file — a mapping of MCP server URI → :class:`AuthCache`.
+
+    YAML on disk::
+
+        https://mcp.dremio.cloud/mcp/<project-id>:
+          token: <access_token>
+          refresh-token: <refresh_token>
+          client-id: <oauth_client_id>
+        https://mcp.eu.dremio.cloud/mcp/<other-project>:
+          token: ...
+    """
+
+    root: dict[str, AuthCache] = Field(default_factory=dict)
+
+    def get(self, url: str) -> AuthCache:
+        return self.root.get(url, AuthCache())
+
+    def set(self, url: str, cache: AuthCache) -> "AuthCacheStore":
+        self.root[url] = cache
+        return self
+
+
+def _read_auth_store() -> AuthCacheStore:
+    """Load the full auth cache store from disk."""
     if not _AUTH_CACHE_PATH.exists():
-        return AuthCache()
+        return AuthCacheStore()
     try:
         data = yaml.safe_load(_AUTH_CACHE_PATH.read_text())
         if isinstance(data, dict):
-            return AuthCache.model_validate(data)
+            return AuthCacheStore.model_validate(data)
     except Exception:
         pass
-    return AuthCache()
+    return AuthCacheStore()
 
 
-def _write_auth_cache(cache: AuthCache) -> None:
-    """Persist *cache* to ``~/.config/dremioai/.auth.yaml``."""
+def _write_auth_store(store: AuthCacheStore) -> None:
+    """Persist the full auth cache store to disk."""
     _AUTH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
     _AUTH_CACHE_PATH.write_text(
-        yaml.safe_dump(cache.model_dump(by_alias=True, exclude_none=True))
+        yaml.safe_dump(store.model_dump(by_alias=True, exclude_none=True))
     )
+
+
+def _read_auth_cache(url: str) -> AuthCache:
+    """Return the :class:`AuthCache` entry for *url*; empty if not found."""
+    return _read_auth_store().get(url)
+
+
+def _write_auth_cache(url: str, cache: AuthCache) -> None:
+    """Write/update the :class:`AuthCache` entry for *url* in the store."""
+    _write_auth_store(_read_auth_store().set(url, cache))
 
 
 def _do_token_refresh(
@@ -139,9 +172,9 @@ def _resolve_token(
     if explicit_token is not None:
         return explicit_token, AuthCache()
 
-    cache = _read_auth_cache()
+    cache = _read_auth_cache(url)
     if cache.token:
-        pp("[dim]Using cached token (~/.config/dremioai/.auth.yaml)[/dim]")
+        pp(f"[dim]Using cached token for {url}[/dim]")
         return cache.token, cache
 
     # No cached token — try the OAuth flow.
@@ -152,7 +185,7 @@ def _resolve_token(
         )
         raise SystemExit(1)
 
-    pp("No cached token found. Starting OAuth flow..")
+    pp(f"No cached token for {url}. Starting OAuth flow..")
     oauth_meta = get_oauth_config(url)
     oauth = get_oauth2_tokens(
         client_id,
@@ -166,8 +199,8 @@ def _resolve_token(
         raise SystemExit(1)
 
     new_cache = AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id)
-    _write_auth_cache(new_cache)
-    pp("[green]Authenticated.[/green]  Token cached at ~/.config/dremioai/.auth.yaml")
+    _write_auth_cache(url, new_cache)
+    pp(f"[green]Authenticated.[/green]  Token cached for {url}")
     return oauth.access_token, new_cache
 
 
@@ -185,7 +218,7 @@ def _handle_token_expired(url: str, cache: AuthCache) -> str | None:
             str(oauth_meta.token_endpoint), cache.client_id, cache.refresh_token
         )
         if new_token:
-            _write_auth_cache(AuthCache(
+            _write_auth_cache(url, AuthCache(
                 token=new_token,
                 refresh_token=new_refresh or cache.refresh_token,
                 client_id=cache.client_id,
@@ -319,7 +352,8 @@ def check_auth(
         redirect_port,
         redirect_path,
     )
-    _write_auth_cache(AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id))
+    if url:
+        _write_auth_cache(url, AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id))
     pp(oauth.access_token)
     return oauth
 
@@ -483,6 +517,64 @@ async def verify_token(
     result_tbl.add_row("jwks_enabled", str(jwks_uri is not None).lower())
     result_tbl.add_row("extract_org_id_from_jwt", str(extract_org_id_from_jwt).lower())
     pp(result_tbl)
+
+
+@auth.command("cache-update")
+def cache_update(
+    url: Annotated[str, Option(help="MCP server URL — used as the cache key")],
+    token: Annotated[str, Option(help="Bearer / access token to store")],
+    refresh_token: Annotated[
+        Optional[str], Option("--refresh-token", help="Refresh token (optional)")
+    ] = None,
+    client_id: Annotated[
+        Optional[str], Option("--client-id", help="OAuth client ID (needed for future refresh)")
+    ] = None,
+):
+    """Write or overwrite the cached credentials for a given MCP server URL.
+
+    Useful when you have a token from another source and want to inject it
+    so that ``list-tools``, ``call-tool``, and ``test`` pick it up automatically::
+
+        auth cache-update --url https://mcp.dremio.cloud/mcp/<proj> \\
+                          --token eyJ... \\
+                          --refresh-token rrt_... \\
+                          --client-id my-client-id
+    """
+    _write_auth_cache(
+        url,
+        AuthCache(token=token, refresh_token=refresh_token, client_id=client_id),
+    )
+    pp(f"[green]Cache updated for[/green] {url}")
+
+
+@auth.command("cache-show")
+def cache_show(
+    url: Annotated[
+        Optional[str], Option(help="Show only the entry for this URL (omit for all)")
+    ] = None,
+):
+    """Display the current auth cache contents (tokens are redacted)."""
+    store = _read_auth_store()
+    if not store.root:
+        pp("[dim]Auth cache is empty.[/dim]")
+        return
+    entries = {url: store.root[url]} if url and url in store.root else store.root
+    if url and url not in store.root:
+        pp(f"[yellow]No cache entry found for {url}[/yellow]")
+        return
+    tbl = Table(title="Auth Cache (~/.config/dremioai/.auth.yaml)")
+    tbl.add_column("URL")
+    tbl.add_column("token")
+    tbl.add_column("refresh-token")
+    tbl.add_column("client-id")
+    for entry_url, entry in entries.items():
+        tbl.add_row(
+            entry_url,
+            _redact_value(entry.token),
+            _redact_value(entry.refresh_token),
+            entry.client_id or "",
+        )
+    pp(tbl)
 
 
 cli = Typer(

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -27,6 +27,7 @@ import requests
 import uvicorn
 import yaml
 from rich import print as pp
+from rich.markdown import Markdown
 from rich.table import Table
 from typer import Typer, Option
 from datetime import datetime
@@ -352,8 +353,13 @@ def check_auth(
         redirect_port,
         redirect_path,
     )
-    if url:
-        _write_auth_cache(url, AuthCache(token=oauth.access_token, refresh_token=oauth.refresh_token, client_id=client_id))
+    if url and oauth.access_token:
+        cache_update(
+            url=url,
+            token=oauth.access_token,
+            refresh_token=oauth.refresh_token,
+            client_id=client_id,
+        )
     pp(oauth.access_token)
     return oauth
 
@@ -628,8 +634,15 @@ async def list_tools(
     ] = None,
 ):
     async with mcp_client_session(url, token) as session:
-        for tool in await session.list_tools():
-            pp(tool)
+        result = await session.list_tools()
+        tools = result.tools
+
+    tbl = Table(title=f"Tools — {url}", show_header=True, header_style="bold", show_lines=True)
+    tbl.add_column("Tool", style="bold cyan", no_wrap=True)
+    tbl.add_column("Description")
+    for tool in tools:
+        tbl.add_row(tool.name, Markdown(tool.description or ""))
+    pp(tbl)
 
 
 @cli.command("call-tool")

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -457,6 +457,12 @@ async def run_test(
             help="Check new-contract changes (param rename, input validation, etc.)"
         ),
     ] = True,
+    check_remote_tools: Annotated[
+        bool,
+        Option(
+            help="Verify remote Dremio tools appear in tools/list and can be called directly"
+        ),
+    ] = False,
     local: Annotated[
         bool, Option(help="Start a local MCP server for running the tests")
     ] = False,
@@ -500,6 +506,7 @@ async def run_test(
             token,
             check_annotations,
             check_new_contract,
+            check_remote_tools=check_remote_tools,
             ld_sdk_key=ld_sdk_key,
             ld_flag=ld_flag,
             ld_expected=ld_expected,
@@ -539,6 +546,7 @@ async def run_test(
             token,
             check_annotations,
             check_new_contract,
+            check_remote_tools=check_remote_tools,
             ld_sdk_key=ld_sdk_key,
             ld_flag=ld_flag,
             ld_expected=ld_expected,
@@ -567,6 +575,7 @@ async def _run_smoketests(
     token: str,
     check_annotations: bool,
     check_new_contract: bool,
+    check_remote_tools: bool = False,
     ld_sdk_key: str | None = None,
     ld_flag: str | None = None,
     ld_expected: str | None = None,
@@ -803,7 +812,34 @@ async def _run_smoketests(
             pp("[green]OK[/green]")
 
         # ------------------------------------------------------------------
-        # 12. LaunchDarkly flag evaluation (optional, requires --ld-sdk-key)
+        # 12. Remote tools: verify they appear in tools/list (optional)
+        # ------------------------------------------------------------------
+        if check_remote_tools:
+            pp("Checking remote tools in tools/list..", end=" ")
+            static_tool_names = {
+                "RunSqlQuery", "GetUsefulSystemTableNames", "GetSchemaOfTable",
+                "GetDescriptionOfTableOrSchema", "GetTableOrViewLineage",
+                "SearchTableAndViews", "DiscoverDynamicTools", "CallDynamicTool",
+            }
+            remote_tools = [t for t in tools_result.tools if t.name not in static_tool_names]
+            _assert(
+                len(remote_tools) > 0,
+                f"No remote tools found in tools/list (got {[t.name for t in tools_result.tools]})",
+            )
+            pp(f"{len(remote_tools)} remote tool(s) found: {[t.name for t in remote_tools]}")
+
+            # Call the first remote tool with no arguments to verify routing works
+            first_remote = remote_tools[0]
+            pp(f"Calling remote tool '{first_remote.name}'..", end=" ")
+            result = await session.call_tool(first_remote.name, {})
+            _assert(
+                result.structuredContent is not None or not result.isError,
+                f"Remote tool call failed: {result.content}",
+            )
+            pp("[green]OK[/green]")
+
+        # ------------------------------------------------------------------
+        # 13. LaunchDarkly flag evaluation (optional, requires --ld-sdk-key)
         # ------------------------------------------------------------------
         if ld_sdk_key and ld_flag:
             pp(f"Checking LD flag '{ld_flag}'..", end=" ")

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -14,6 +14,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Annotated, Optional, AsyncGenerator, Callable, Any, Dict
 from urllib.parse import urlparse
 
@@ -23,6 +24,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthMetadata
 import requests
 import uvicorn
+import yaml
 from rich import print as pp
 from rich.table import Table
 from typer import Typer, Option
@@ -47,6 +49,151 @@ def async_command(func: Callable) -> Callable:
 
     return wrapper
 
+
+# ---------------------------------------------------------------------------
+# Auth-cache helpers
+# ---------------------------------------------------------------------------
+
+_AUTH_CACHE_PATH = Path.home() / ".config" / "dremioai" / ".auth.yaml"
+
+
+class _TokenExpiredError(Exception):
+    """Raised when a 401 Unauthorized is detected from the MCP server."""
+
+
+def _read_auth_cache() -> dict:
+    """Read ~/.config/dremioai/.auth.yaml; returns {} when absent or malformed."""
+    if not _AUTH_CACHE_PATH.exists():
+        return {}
+    try:
+        data = yaml.safe_load(_AUTH_CACHE_PATH.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_auth_cache(
+    token: str,
+    refresh_token: str | None = None,
+    client_id: str | None = None,
+) -> None:
+    """Persist token (and optionally refresh-token / client-id) to the auth cache."""
+    _AUTH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {"token": token}
+    if refresh_token:
+        data["refresh-token"] = refresh_token
+    if client_id:
+        data["client-id"] = client_id
+    _AUTH_CACHE_PATH.write_text(yaml.safe_dump(data))
+
+
+def _do_token_refresh(
+    token_endpoint: str, client_id: str, refresh_token: str
+) -> tuple[str | None, str | None]:
+    """POST to *token_endpoint* to exchange *refresh_token* for a new access token.
+
+    Returns ``(new_access_token, new_refresh_token)``.  The new refresh token
+    may be ``None`` when the server does not rotate refresh tokens.
+    """
+    try:
+        resp = requests.post(
+            token_endpoint,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            body = resp.json()
+            return body.get("access_token"), body.get("refresh_token")
+        pp(f"[yellow]Token refresh returned HTTP {resp.status_code}[/yellow]")
+    except Exception as exc:
+        pp(f"[yellow]Token refresh request failed: {exc}[/yellow]")
+    return None, None
+
+
+def _resolve_token(
+    explicit_token: str | None,
+    url: str,
+    client_id: str | None,
+    redirect_port: int,
+    redirect_path: str,
+) -> tuple[str, dict]:
+    """Return the bearer token to use, in priority order:
+
+    1. *explicit_token* (``--token`` flag) — cache is bypassed entirely.
+    2. ``~/.config/dremioai/.auth.yaml`` ``token:`` key.
+    3. Full OAuth PKCE flow (requires *client_id*); writes result to cache.
+
+    Returns ``(token, cache_dict)``.  *cache_dict* is empty when the caller
+    supplied an explicit token.
+    """
+    if explicit_token is not None:
+        return explicit_token, {}
+
+    cache = _read_auth_cache()
+    cached_token = cache.get("token")
+    if cached_token:
+        pp("[dim]Using cached token (~/.config/dremioai/.auth.yaml)[/dim]")
+        return cached_token, cache
+
+    # No cached token — try the OAuth flow.
+    if not client_id:
+        pp(
+            "[red]No token available.[/red]  "
+            "Provide --token, or use --client-id to authenticate via OAuth."
+        )
+        raise SystemExit(1)
+
+    pp("No cached token found. Starting OAuth flow..")
+    oauth_meta = get_oauth_config(url)
+    oauth = get_oauth2_tokens(
+        client_id,
+        str(oauth_meta.authorization_endpoint),
+        str(oauth_meta.token_endpoint),
+        redirect_port,
+        redirect_path,
+    )
+    if not oauth.access_token:
+        pp("[red]OAuth flow did not return a token.[/red]")
+        raise SystemExit(1)
+
+    _write_auth_cache(oauth.access_token, oauth.refresh_token, client_id)
+    pp(
+        "[green]Authenticated.[/green]  "
+        "Token cached at ~/.config/dremioai/.auth.yaml"
+    )
+    return oauth.access_token, _read_auth_cache()
+
+
+def _handle_token_expired(url: str, cache: dict) -> str | None:
+    """Attempt a token refresh using the cached refresh token.
+
+    On success writes the new token to cache and returns it.
+    Returns ``None`` if the cache lacks a refresh token or the refresh fails.
+    """
+    refresh_tok = cache.get("refresh-token")
+    client_id = cache.get("client-id")
+    if not (refresh_tok and client_id):
+        return None
+    try:
+        oauth_meta = get_oauth_config(url)
+        new_token, new_refresh = _do_token_refresh(
+            str(oauth_meta.token_endpoint), client_id, refresh_tok
+        )
+        if new_token:
+            _write_auth_cache(new_token, new_refresh or refresh_tok, client_id)
+            return new_token
+    except Exception as exc:
+        pp(f"[yellow]Token refresh failed: {exc}[/yellow]")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Typer apps
+# ---------------------------------------------------------------------------
 
 app = Typer(
     no_args_is_help=True,
@@ -126,6 +273,7 @@ def check_auth(
         redirect_port,
         redirect_path,
     )
+    _write_auth_cache(oauth.access_token, oauth.refresh_token, client_id)
     pp(oauth.access_token)
     return oauth
 
@@ -299,19 +447,31 @@ cli = Typer(
 )
 
 
+def _is_auth_error(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "401" in msg or "unauthorized" in msg or "unauthenticated" in msg
+
+
 @asynccontextmanager
 async def mcp_client_session(
     url: str, token: Optional[str] = None
 ) -> AsyncGenerator[ClientSession, None]:
     headers = {"Authorization": f"Bearer {token}"} if token is not None else None
-    async with streamablehttp_client(url=url, headers=headers) as (
-        read_stream,
-        write_stream,
-        gid,
-    ):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            yield session
+    try:
+        async with streamablehttp_client(url=url, headers=headers) as (
+            read_stream,
+            write_stream,
+            gid,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+    except _TokenExpiredError:
+        raise  # already converted — let it propagate
+    except Exception as exc:
+        if _is_auth_error(exc):
+            raise _TokenExpiredError(str(exc)) from exc
+        raise
 
 
 @cli.command("list-tools")
@@ -323,11 +483,27 @@ async def list_tools(
     token: Annotated[
         Optional[str], Option(help="The authorization token to use")
     ] = None,
+    client_id: Annotated[
+        Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
+    ] = None,
 ):
-    async with mcp_client_session(url, token) as session:
-        tools = await session.list_tools()
-        for tool in tools:
-            pp(tool)
+    resolved_token, cache = _resolve_token(token, url, client_id, 8976, "/")
+
+    async def _do(tok: str) -> None:
+        async with mcp_client_session(url, tok) as session:
+            tools = await session.list_tools()
+            for tool in tools:
+                pp(tool)
+
+    try:
+        await _do(resolved_token)
+    except _TokenExpiredError:
+        pp("[yellow]Token expired — refreshing...[/yellow]")
+        new_token = _handle_token_expired(url, cache)
+        if not new_token:
+            pp("[red]Refresh failed. Re-authenticate with --client-id.[/red]")
+            raise SystemExit(1)
+        await _do(new_token)
 
 
 @cli.command("call-tool")
@@ -340,17 +516,33 @@ async def call_tool(
     token: Annotated[
         Optional[str], Option(help="The authorization token to use")
     ] = None,
+    client_id: Annotated[
+        Optional[str], Option(help="OAuth client ID (used when no --token or cached token)")
+    ] = None,
     args: Annotated[
         Optional[str], Option(help="The arguments to pass to the tool as a JSON")
     ] = None,
 ):
-    async with mcp_client_session(url, token) as session:
-        result = await session.call_tool(tool, json.loads(args) if args else None)
-        if result.isError:
-            pp("[red]Error[/red]")
-            pp(result.content)
-            return
-        pp(result.structuredContent["result"])
+    resolved_token, cache = _resolve_token(token, url, client_id, 8976, "/")
+
+    async def _do(tok: str) -> None:
+        async with mcp_client_session(url, tok) as session:
+            result = await session.call_tool(tool, json.loads(args) if args else None)
+            if result.isError:
+                pp("[red]Error[/red]")
+                pp(result.content)
+                return
+            pp(result.structuredContent["result"])
+
+    try:
+        await _do(resolved_token)
+    except _TokenExpiredError:
+        pp("[yellow]Token expired — refreshing...[/yellow]")
+        new_token = _handle_token_expired(url, cache)
+        if not new_token:
+            pp("[red]Refresh failed. Re-authenticate with --client-id.[/red]")
+            raise SystemExit(1)
+        await _do(new_token)
 
 
 def _assert(condition: bool, msg: str):
@@ -488,29 +680,36 @@ async def run_test(
     ] = "/",
 ):
     if not local:
-        # Remote mode: connect directly to the URL
-        if token is None and client_id is None:
-            pp(
-                "[red]FAIL[/red] Provide either --client-id (for OAuth) or --token (for direct auth)"
-            )
-            raise SystemExit(1)
-        if token is None:
-            pp("Checking auth..", end=" ")
-            a = check_auth(client_id, url, redirect_port, redirect_path)
-            token = a.access_token
-            pp("[green]OK[/green]")
-        else:
-            pp("Using provided token, skipping OAuth..")
-        await _run_smoketests(
-            url,
-            token,
-            check_annotations,
-            check_new_contract,
-            check_remote_tools=check_remote_tools,
-            ld_sdk_key=ld_sdk_key,
-            ld_flag=ld_flag,
-            ld_expected=ld_expected,
+        # Remote mode — resolve the token, then run smoketests with 401 retry.
+        resolved_token, cache = _resolve_token(
+            token, url, client_id, redirect_port, redirect_path
         )
+
+        async def _do_remote_tests(tok: str) -> None:
+            await _run_smoketests(
+                url,
+                tok,
+                check_annotations,
+                check_new_contract,
+                check_remote_tools=check_remote_tools,
+                ld_sdk_key=ld_sdk_key,
+                ld_flag=ld_flag,
+                ld_expected=ld_expected,
+            )
+
+        try:
+            await _do_remote_tests(resolved_token)
+        except _TokenExpiredError:
+            pp("[yellow]Token expired — refreshing...[/yellow]")
+            new_token = _handle_token_expired(url, cache)
+            if not new_token:
+                pp(
+                    "[red]Token refresh failed.[/red]  "
+                    "Re-authenticate with --client-id or supply a new --token."
+                )
+                raise SystemExit(1)
+            pp("[green]Token refreshed — retrying...[/green]")
+            await _do_remote_tests(new_token)
         return
 
     # Local mode: start a local MCP server and test against it

--- a/tests/stremable_http_cli.py
+++ b/tests/stremable_http_cli.py
@@ -626,28 +626,18 @@ cli = Typer(
 )
 
 
-def _unwrap_401(exc: BaseException) -> httpx.HTTPStatusError | None:
-    """Return the first HTTPStatusError with status 401 buried inside *exc*.
-
-    ``streamablehttp_client`` runs streams inside an anyio/asyncio TaskGroup,
-    so transport-level errors arrive wrapped in an ``ExceptionGroup``.  This
-    function recursively unwraps both plain exceptions and ExceptionGroups to
-    find the culprit.
-    """
-    if isinstance(exc, httpx.HTTPStatusError):
-        return exc if exc.response.status_code == 401 else None
-    if isinstance(exc, BaseExceptionGroup):
-        for sub in exc.exceptions:
-            found = _unwrap_401(sub)
-            if found is not None:
-                return found
-    return None
-
-
 @asynccontextmanager
 async def mcp_client_session(
     url: str, token: Optional[str] = None
 ) -> AsyncGenerator[ClientSession, None]:
+    """Open a ``ClientSession`` against *url*, converting 401 responses to
+    :class:`TokenExpiredError` so that :func:`with_auth` can refresh and retry.
+
+    ``streamablehttp_client`` runs its read/write streams inside an anyio
+    ``TaskGroup``, so ``httpx.HTTPStatusError`` arrives wrapped in a
+    ``BaseExceptionGroup``.  The ``except*`` syntax (PEP 654) handles both the
+    bare and the group-wrapped case transparently.
+    """
     headers = {"Authorization": f"Bearer {token}"} if token is not None else None
     try:
         async with streamablehttp_client(url=url, headers=headers) as (
@@ -658,17 +648,13 @@ async def mcp_client_session(
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
                 yield session
-    except TokenExpiredError:
-        raise  # already converted — let it propagate
-    except BaseException as exc:
-        # streamablehttp_client wraps transport errors in ExceptionGroup; unwrap
-        # to find any 401 HTTPStatusError before falling back to text matching.
-        if found := _unwrap_401(exc):
-            raise TokenExpiredError(str(found)) from found
-        msg = str(exc).lower()
-        if "401" in msg or "unauthorized" in msg:
-            raise TokenExpiredError(str(exc)) from exc
-        raise
+    except* TokenExpiredError:
+        raise  # already converted upstream — propagate as-is
+    except* httpx.HTTPStatusError as eg:
+        for exc in eg.exceptions:
+            if exc.response.status_code == 401:
+                raise TokenExpiredError(str(exc)) from exc
+        raise  # non-401 HTTP errors propagate unchanged
 
 
 @cli.command("list-tools")

--- a/tests/test_fastmcp_basic.py
+++ b/tests/test_fastmcp_basic.py
@@ -108,8 +108,8 @@ async def test_create_fastmcp_server_and_register_tools():
                 "GetUsefulSystemTableNames": {},
                 "GetTableOrViewLineage": {"table_name": "test_table"},
                 "GetDescriptionOfTableOrSchema": {"name": "test_table"},
-                "DiscoverDynamicTools": {},
-                "CallDynamicTool": {"tool_name": "SomeTool", "tool_arguments": "{}"},
+                "SearchMetrics": {"query": "revenue"},
+                "GetTableRelationships": {"path": ["Samples", "test_table"]},
             }
             for tool in tools_list:
                 if (

--- a/tests/test_simple_fastmcp_server.py
+++ b/tests/test_simple_fastmcp_server.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, patch
 import pandas as pd
 import pytest
 
-from dremioai.api.dremio.ai_tools import InvokeToolResponse, ListToolsResponse
+from dremioai.api.dremio.ai_tools import InvokeToolResponse, InvokeToolResponseResult, ListToolsResponse
 from dremioai.config import settings
 from dremioai.config.tools import ToolType
 from dremioai.servers import mcp as mcp_server
@@ -266,7 +266,7 @@ class TestDynamicTools:
             with patch(
                 "dremioai.tools.tools.ai_tools.invoke_tool",
                 new_callable=AsyncMock,
-                return_value=InvokeToolResponse(result="hello"),
+                return_value=InvokeToolResponse(result=InvokeToolResponseResult.model_validate({"value": "hello"})),
             ) as mock_invoke:
                 result = await server.call_tool(
                     "CallDynamicTool",

--- a/tests/test_simple_fastmcp_server.py
+++ b/tests/test_simple_fastmcp_server.py
@@ -181,7 +181,7 @@ class TestDynamicTools:
     async def test_meta_tools_registered_when_enabled(self):
         """Both meta-tools should appear in tool list when enable_remote_tools is True"""
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
             tool_names = {t.name for t in await server.list_tools()}
             assert "DiscoverDynamicTools" in tool_names
             assert "CallDynamicTool" in tool_names
@@ -190,7 +190,7 @@ class TestDynamicTools:
     async def test_meta_tools_disabled_at_invocation(self):
         """Meta-tools appear in the list but return an error when enable_remote_tools is False"""
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=False):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
             tool_names = {t.name for t in await server.list_tools()}
             assert "DiscoverDynamicTools" in tool_names
             assert "CallDynamicTool" in tool_names
@@ -226,7 +226,7 @@ class TestDynamicTools:
         )
 
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
 
             with patch(
                 "dremioai.tools.tools.ai_tools.list_tools",
@@ -244,7 +244,7 @@ class TestDynamicTools:
     @pytest.mark.asyncio
     async def test_discover_returns_error_on_dremio_failure(self):
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
 
             with patch(
                 "dremioai.tools.tools.ai_tools.list_tools",
@@ -261,7 +261,7 @@ class TestDynamicTools:
     async def test_call_dynamic_tool_proxies_to_invoke_tool(self):
         """CallDynamicTool should proxy to ai_tools.invoke_tool with correct args"""
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
 
             with patch(
                 "dremioai.tools.tools.ai_tools.invoke_tool",
@@ -281,7 +281,7 @@ class TestDynamicTools:
     @pytest.mark.asyncio
     async def test_call_dynamic_tool_returns_error_on_failure(self):
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
 
             with patch(
                 "dremioai.tools.tools.ai_tools.invoke_tool",
@@ -305,7 +305,7 @@ class TestDynamicTools:
     async def test_call_dynamic_tool_with_invalid_json(self):
         """CallDynamicTool should return a graceful error for non-JSON arguments"""
         with self.mock_settings_for_dynamic_tools(enable_remote_tools=True):
-            server = mcp_server.init(mode=ToolType.FOR_DATA_PATTERNS)
+            server = mcp_server.init(mode=ToolType.DYNAMIC_REMOTE_TOOLS)
 
             result = await server.call_tool(
                 "CallDynamicTool",


### PR DESCRIPTION
## Summary

### Core: request-scoped dynamic MCP tools (`src/dremioai/`)

- Override `list_tools()` and `call_tool()` in `FastMCPServerWithAuthToken` to merge static + request-scoped remote Dremio tools into a single `tools/list` response — LLMs no longer need a prior `DiscoverDynamicTools` call.
- Remote tools fetched via `@secured`-decorated `_list_remote_tools` / `_invoke_remote_tool` helpers, injecting request-scoped `PAT` + `project_id` without reimplementing `@secured`.
- `call_tool` delegates static tools to `super()`, routes remote tools directly through `_invoke_remote_tool` (bypasses `_tool_cache`), returns `result.model_dump(exclude_none=True)`.
- `DiscoverDynamicTools` / `CallDynamicTool` moved to new `ToolType.DYNAMIC_REMOTE_TOOLS` flag — no longer registered in default `FOR_DATA_PATTERNS` / `FOR_SELF` modes.
- New `dremioai ai-tools list` / `ai-tools call` CLI commands (`src/dremioai/api/cli/ai_tools.py`).

### Semantic layer tools

- `SearchMetrics(query)` and `GetTableRelationships(path: List[str])` — typed MCP tool classes (`FOR_DATA_PATTERNS | EXPERIMENTAL`) that call `invoke_tool("searchMetrics", ...)` / `invoke_tool("getTableRelationShips", ...)` respectively; gated on `dremio.enable_semantic_layer`.
- `SearchTableAndViews` gains:
  - `topN: Optional[int] = None` — defaults to `dremio.search_topN` (default **10**), capped to that limit; communicates non-exhaustive nature to the LLM.
  - `get_description()` override — when `enable_semantic_layer` is true, calls `ai_tools.get_semantic_layer_tool_descriptions()` at server-init time to embed live server-supplied descriptions for `searchMetrics` and `getTableRelationships` in the tool description.
  - Parallel `getTableRelationShips` enrichment per TABLE/VIEW result → added as `"relationships"` key (parsed via typed `TableRelationship` model).
  - Parallel `searchMetrics` call → metric results appended with `"result_type": "METRIC"` (parsed via typed `Metric` / `MetricsSearchResult` models).

### Typed semantic-layer wire models (`src/dremioai/api/dremio/ai_tools.py`)

- `TableRelationship` / `RelationshipUsage` — mirrors Java `ImmutableTableRelationship` (camelCase aliases).
- `Metric` / `MetricUsage` / `MetricColumn` / `MetricsSearchResult` — mirrors Java `ImmutableMetric`; handles `{"errorMessage": ..., "metrics": [...]}` envelope.
- `get_semantic_layer_tool_descriptions()` async helper — fetches descriptions for `searchMetrics` / `getTableRelationships` from the AI tool registry.

### Settings (`src/dremioai/config/settings.py`)

- `dremio.enable_semantic_layer` — `bool`, default `False`; `RuntimeMutable` (LaunchDarkly hot-toggle).
- `dremio.search_topN` — `int`, default **10**; caps `SearchTableAndViews` result count.
- `dremio.enable_remote_tools` — existing flag; gates remote tool passthrough in `list_tools` / `call_tool`.

### Streamable HTTP CLI (`tests/stremable_http_cli.py`)

- Token resolution: `--token` → `~/.config/dremioai/.auth.yaml` (keyed by normalized MCP URL) → OAuth PKCE flow; token + refresh-token cached on success.
- `TokenExpiredError` + `except* httpx.HTTPStatusError` — uses Python 3.11 `except*` (PEP 654) to unwrap `HTTPStatusError` from the `ExceptionGroup` emitted by `streamablehttp_client`'s internal `TaskGroup`; retries once after refresh.
- `AuthCache` / `AuthCacheStore` (`RootModel[dict[str, AuthCache]]`) — Pydantic models; cache keyed by `_normalize_url()` (adds `https://`, strips trailing `/`).
- `@with_auth` decorator on `cli list-tools` / `cli call-tool` — resolves token and handles refresh transparently.
- `auth check` → delegates cache write to `auth cache-update`; `auth cache-show` displays a redacted table.
- `cli list-tools` renders a Rich table with tool descriptions as Markdown.
- `--redirect-port` / `--redirect-path` on `cli list-tools` and `cli call-tool` for OAuth PKCE callbacks.

## Test plan

- [ ] `uv run pytest tests/servers/test_remote_tools.py -v` — 9 unit tests (merged listing, disabled flag, remote invocation, static routing, no cross-project cache, name collision, unknown tool, API error degradation, disabled-mode error dict)
- [ ] `uv run pytest tests/ -v` — 382 passed, 4 skipped, 0 failures
- [ ] `uv run python tests/stremable_http_cli.py cli list-tools --url https://mcp.qa.dremio.site/mcp/<proj> --client-id https://connectors.dremio.app/claude --redirect-path /Callback`
- [ ] `uv run python tests/stremable_http_cli.py auth check --url https://mcp.qa.dremio.site/mcp/<proj> --client-id https://connectors.dremio.app/claude --redirect-path /Callback` then `auth cache-show`
- [ ] E2E smoketest with `--check-remote-tools` flag against a Dremio instance with `enable_remote_tools: true`
- [ ] Semantic layer: enable `dremio.enable_semantic_layer: true` and verify `SearchTableAndViews` description includes `searchMetrics` / `getTableRelationships` descriptions, results include `"relationships"` and `"result_type": "METRIC"` entries

## JIRA

https://dremio.atlassian.net/browse/DX-122122

🤖 Generated with [Claude Code](https://claude.com/claude-code)