### PR TITLE
DX-124126: Switch base image to Alpine to clear CVE-2026-57432 and its siblings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM python:3.13-slim AS builder
+FROM python:3.13.14-alpine3.24 AS builder
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
@@ -19,18 +19,20 @@ RUN uv build --wheel -o /dist
 
 
 # Runtime stage
-FROM python:3.13-slim
+FROM python:3.13.14-alpine3.24
 
-# Create non-root user
-RUN useradd -m -u 1001 appuser
+# Create non-root user (Alpine/busybox: adduser, not useradd)
+RUN adduser -D -u 1001 appuser
 
 WORKDIR /app
 
 # Copy wheel from builder
 COPY --from=builder /dist/*.whl /dist/requirements.txt /tmp/
 
-# Install the wheel and dependencies
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+# Install the wheel and dependencies. --only-binary=:all: fails the build
+# loudly if a future dependency lacks a musllinux wheel, instead of silently
+# compiling from source (and needing a C toolchain we don't install here).
+RUN pip install --no-cache-dir --only-binary=:all: -r /tmp/requirements.txt
 RUN pip install --no-cache-dir /tmp/dremioai*.whl
 RUN rm /tmp/*.whl /tmp/requirements.txt
 


### PR DESCRIPTION
The Trivy scan of the image flagged perl-base 5.40.1-6 for an integer overflow in S_measure_struct that lets a crafted pack/unpack template read heap memory out of bounds. perl-base is not a Python dependency of this project — it ships as an Essential package in the python:3.13-slim (Debian trixie) base image, unrelated to anything in pyproject.toml/uv.lock. There is no fixed Debian version to upgrade to either: `apt-cache policy perl-base` in the base image shows 5.40.1-6 is already the newest candidate in the trixie repos.

Rather than purge just perl-base, a full Trivy scan of the base image showed it's one of many: python:3.13-slim (debian 13.6) carries 168 OS CVEs (3 CRITICAL, 19 HIGH), spread across perl-base, util-linux and friends (bsdutils, mount, login, libblkid1, libmount1, libuuid1, liblastlog2-2), ncurses, and gzip — none with fixed versions available yet. Purging packages one Jira ticket at a time doesn't scale against that queue, so this switches the base image to
python:3.13.14-alpine3.24, which Trivy reports as 0 OS vulnerabilities (HIGH/CRITICAL or otherwise).

Verified before making the switch:
- All 80 locked runtime dependencies (including native-extension packages: pandas, numpy, cryptography, pydantic-core, orjson, yarl) have musllinux wheels: `pip install --only-binary=:all: --dry-run` against the exported requirements.txt resolves cleanly on python:3.13.14-alpine3.24, so nothing needs to compile from source.
- The full multi-stage build succeeds unchanged apart from two Alpine/musl adjustments: `useradd` -> `adduser -D` (no useradd on busybox), and `pip install` gained `--only-binary=:all:` so a future dependency without a musllinux wheel fails the build loudly instead of silently falling back to a source build.
- The built image runs `dremio-mcp-server --help`/`run` correctly under the non-root appuser, and importing every native-extension dependency (pandas, numpy, cryptography, pydantic_core, aiohttp, orjson, PyJWT) succeeds.
- A Trivy scan of the resulting image confirms 0 OS-level vulnerabilities, versus 22 HIGH/CRITICAL on the trixie-based image.
- Base image size drops from 381 MB to 144 MB.

Known musl trade-offs, judged not applicable here: smaller default thread stack size (this is an asyncio-based I/O-bound service, not thread-heavy), and musl's malloc has historically been slower under heavy multithreaded allocation churn (same reasoning applies). Alpine's musl 1.2.4+ (3.18+) also fixed the old DNS-over-TCP truncation issue.